### PR TITLE
Adding image format arg to OpenAI interface

### DIFF
--- a/marker/services/openai.py
+++ b/marker/services/openai.py
@@ -27,15 +27,39 @@ class OpenAIService(BaseService):
     openai_api_key: Annotated[
         str, "The API key to use for the OpenAI-like service."
     ] = None
+    openai_image_format: Annotated[
+        str, "The image format to use for the OpenAI-like service. Use 'png' for better compatability"
+    ] = 'webp'
 
-    def image_to_base64(self, image: PIL.Image.Image):
+    def image_to_base64(self, image: PIL.Image.Image) -> str:
+        """
+        Convert PIL image to base64 string
+
+        Args:
+            image: Input PIL Image
+            format: Format to use for the image; use "png" for better compatability.
+
+        Returns:
+            Base-64 encoded image (in PNG format) to pass to LLM.
+        """
         image_bytes = BytesIO()
-        image.save(image_bytes, format="WEBP")
+        image.save(image_bytes, format=self.openai_image_format)
         return base64.b64encode(image_bytes.getvalue()).decode("utf-8")
 
     def prepare_images(
         self, images: Union[Image.Image, List[Image.Image]]
     ) -> List[dict]:
+        """
+        Generate the base-64 encoded message to send to an
+        openAI-compatabile multimodal model.
+
+        Args:
+            images: Image or list of PIL images to include
+            format: Format to use for the image; use "png" for better compatability.
+
+        Returns:
+            A list of OpenAI-compatbile multimodal messages containing the base64-encoded images.
+        """
         if isinstance(images, Image.Image):
             images = [images]
 
@@ -43,7 +67,8 @@ class OpenAIService(BaseService):
             {
                 "type": "image_url",
                 "image_url": {
-                    "url": "data:image/webp;base64,{}".format(
+                    "url": "data:image/{};base64,{}".format(
+                        self.openai_image_format,
                         self.image_to_base64(img)
                     ),
                 },

--- a/signatures/version1/cla.json
+++ b/signatures/version1/cla.json
@@ -231,6 +231,14 @@
       "created_at": "2025-06-01T20:10:35Z",
       "repoId": 712111618,
       "pullRequestNo": 721
+    },
+    {
+      "name": "rgeorgi",
+      "id": 805862,
+      "comment_id": 2968063099,
+      "created_at": "2025-06-12T20:23:50Z",
+      "repoId": 712111618,
+      "pullRequestNo": 751
     }
   ]
 }


### PR DESCRIPTION
Add an argument for the openai service image format

Using LM studio to serve a Qwen Vision LM appeared to crash with base64-encoded png, but not webp. To add compatability with this (and potentially other models) this adds a `openai_image_format` string that gets passed to the mimetype and PIL.save() arguments.

Defaults to ‘webp’ that it was originally hardcoded as.

Also adding docstrings for clarity.

Resolves Issue #753 