### PR TITLE
DRAFT | Add Rules parser to Marker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -177,3 +177,5 @@ cython_debug/
 .idea/
 
 .vscode/
+
+local_notes

--- a/examples/plos_paper.yaml
+++ b/examples/plos_paper.yaml
@@ -1,0 +1,14 @@
+version: "1.0"
+rules:
+  layout:
+    type: "plos_paper"
+    # Automatically detect and exclude the metadata gutter on the left
+    exclude_metadata_gutter: true
+    # Main content is a single column, read top-down
+    main_content:
+      type: "single_column"
+      order: "top_down"
+    # Optional: Can specify custom width thresholds if needed
+    thresholds:
+      gutter_width_ratio: 0.4  # Typical width ratio of the metadata gutter
+      main_content_width_ratio: 0.6  # Typical width ratio of the main content 

--- a/examples/plos_paper.yaml
+++ b/examples/plos_paper.yaml
@@ -6,7 +6,6 @@ rules:
       position: "left"
       # The width of the gutter as a ratio of the page width
       width_ratio: 0.4
-    # Main content is a single column, read top-down
-    main_content:
-      type: "single_column"
+    - type: "main_content"
+      # Main content is a single column, read top-down
       order: "top_down"

--- a/examples/plos_paper.yaml
+++ b/examples/plos_paper.yaml
@@ -1,14 +1,12 @@
 version: "1.0"
 rules:
   layout:
-    type: "plos_paper"
-    # Automatically detect and exclude the metadata gutter on the left
-    exclude_metadata_gutter: true
+    - type: "exclude_gutter"
+      # Exclude the left-hand metadata gutter
+      position: "left"
+      # The width of the gutter as a ratio of the page width
+      width_ratio: 0.4
     # Main content is a single column, read top-down
     main_content:
       type: "single_column"
       order: "top_down"
-    # Optional: Can specify custom width thresholds if needed
-    thresholds:
-      gutter_width_ratio: 0.4  # Typical width ratio of the metadata gutter
-      main_content_width_ratio: 0.6  # Typical width ratio of the main content 

--- a/marker/config/parser.py
+++ b/marker/config/parser.py
@@ -82,6 +82,12 @@ class ConfigParser:
             default=None,
             help="LLM service to use - should be full import path, like marker.services.gemini.GoogleGeminiService",
         )(fn)
+        fn = click.option(
+            "--rules",
+            type=str,
+            default=None,
+            help="Path to YAML file with parsing rules.",
+        )(fn)
         return fn
 
     def generate_config_dict(self) -> Dict[str, any]:
@@ -106,6 +112,8 @@ class ConfigParser:
                     config["pdftext_workers"] = 1
                 case "disable_image_extraction":
                     config["extract_images"] = False
+                case "rules":
+                    config["rules_path"] = v
                 case _:
                     if k in crawler.attr_set:
                         config[k] = v

--- a/marker/converters/__init__.py
+++ b/marker/converters/__init__.py
@@ -6,6 +6,7 @@ from pydantic import BaseModel
 from marker.processors import BaseProcessor
 from marker.processors.llm import BaseLLMSimpleBlockProcessor
 from marker.processors.llm.llm_meta import LLMSimpleBlockMetaProcessor
+from marker.rules import RuleEngine
 from marker.util import assign_config, download_font
 
 
@@ -14,6 +15,7 @@ class BaseConverter:
         assign_config(self, config)
         self.config = config
         self.llm_service = None
+        self.rule_engine: RuleEngine | None = None
 
         # Download render font, needed for some providers
         download_font()
@@ -31,6 +33,8 @@ class BaseConverter:
                 continue
             elif param_name == 'config':
                 resolved_kwargs[param_name] = self.config
+            elif param.name == 'rule_engine':
+                resolved_kwargs[param_name] = self.rule_engine
             elif param.name in self.artifact_dict:
                 resolved_kwargs[param_name] = self.artifact_dict[param_name]
             elif param.default != inspect.Parameter.empty:

--- a/marker/converters/pdf.py
+++ b/marker/converters/pdf.py
@@ -50,6 +50,7 @@ from marker.processors.order import OrderProcessor
 from marker.services.gemini import GoogleGeminiService
 from marker.processors.line_merge import LineMergeProcessor
 from marker.processors.llm.llm_mathblock import LLMMathBlockProcessor
+from marker.rules import RuleEngine
 
 
 class PdfConverter(BaseConverter):
@@ -109,6 +110,9 @@ class PdfConverter(BaseConverter):
 
         if config is None:
             config = {}
+
+        self.rule_engine = RuleEngine(config.get("rules_path"))
+        artifact_dict["rule_engine"] = self.rule_engine
 
         for block_type, override_block_type in self.override_map.items():
             register_block_class(block_type, override_block_type)

--- a/marker/converters/pdf.py
+++ b/marker/converters/pdf.py
@@ -47,6 +47,7 @@ from marker.schema.registry import register_block_class
 from marker.util import strings_to_classes
 from marker.processors.llm.llm_handwriting import LLMHandwritingProcessor
 from marker.processors.order import OrderProcessor
+from marker.processors.layout_rules import LayoutRuleProcessor
 from marker.services.gemini import GoogleGeminiService
 from marker.processors.line_merge import LineMergeProcessor
 from marker.processors.llm.llm_mathblock import LLMMathBlockProcessor
@@ -70,6 +71,7 @@ class PdfConverter(BaseConverter):
         "Enable higher quality processing with LLMs.",
     ] = False
     default_processors: Tuple[BaseProcessor, ...] = (
+        LayoutRuleProcessor,
         OrderProcessor,
         BlockRelabelProcessor,
         LineMergeProcessor,

--- a/marker/processors/layout_rules.py
+++ b/marker/processors/layout_rules.py
@@ -1,0 +1,55 @@
+from typing import List, Dict, Optional, Tuple
+
+from marker.processors import BaseProcessor
+from marker.rules import RuleEngine
+from marker.schema.document import Document
+from marker.schema.groups.page import PageGroup
+from marker.schema.blocks import Block
+
+
+class LayoutRuleProcessor(BaseProcessor):
+    """
+    A processor for applying layout rules from the rule engine.
+    This handles things like filtering out regions or defining column layouts.
+    """
+    block_types = tuple()
+
+    def __init__(self, rule_engine: RuleEngine, config=None):
+        self.rule_engine = rule_engine
+        super().__init__(config)
+
+    def apply_rules(self, page: PageGroup, document: Document):
+        """
+        Applies layout rules to a page.
+        """
+        layout_rules = self.rule_engine.get_rules("layout")
+        if not layout_rules:
+            return
+
+        for rule in layout_rules:
+            if rule.get("type") == "exclude_gutter":
+                self.apply_exclude_gutter_rule(page, document, rule)
+
+    def apply_exclude_gutter_rule(self, page: PageGroup, document: Document, rule: Dict):
+        position = rule.get("position")
+        width_ratio = rule.get("width_ratio")
+
+        if not position or not width_ratio:
+            return
+
+        page_width = page.polygon.width
+        blocks_to_remove = []
+
+        for block_id in page.structure:
+            block = document.get_block(block_id)
+            if position == "left" and block.polygon.x_end < page_width * width_ratio:
+                blocks_to_remove.append(block_id)
+            elif position == "right" and block.polygon.x_start > page_width * (1 - width_ratio):
+                blocks_to_remove.append(block_id)
+
+        page.remove_structure_items(blocks_to_remove)
+
+
+    def __call__(self, document: Document):
+        for page in document.pages:
+            self.apply_rules(page, document) 

--- a/marker/rules.py
+++ b/marker/rules.py
@@ -21,7 +21,7 @@ class RuleEngine:
         with open(rules_path, 'r', encoding='utf-8') as f:
             return yaml.safe_load(f)
 
-    def get_rules(self, stage: str) -> Optional[Dict[str, Any]]:
+    def get_rules(self, stage: str, default: Any = None) -> Optional[Any]:
         if not self.rules:
-            return None
-        return self.rules.get("rules", {}).get(stage) 
+            return default
+        return self.rules.get("rules", {}).get(stage, default)

--- a/marker/rules.py
+++ b/marker/rules.py
@@ -1,0 +1,27 @@
+from typing import Optional, Dict, Any
+
+import yaml
+
+from marker.logger import get_logger
+
+logger = get_logger()
+
+
+class RuleEngine:
+    def __init__(self, rules_path: Optional[str]):
+        self.rules: Dict[str, Any] = {}
+        if rules_path:
+            try:
+                self.rules = self._load_rules(rules_path)
+            except Exception as e:
+                logger.warning(f"Could not load rules from {rules_path}: {e}")
+                pass
+
+    def _load_rules(self, rules_path: str) -> Dict[str, Any]:
+        with open(rules_path, 'r', encoding='utf-8') as f:
+            return yaml.safe_load(f)
+
+    def get_rules(self, stage: str) -> Optional[Dict[str, Any]]:
+        if not self.rules:
+            return None
+        return self.rules.get("rules", {}).get(stage) 


### PR DESCRIPTION
🚧 Still working on it (only 3 hours in!)

## Context

Adds a rules engine to guarantee how well `marker` converts a PDF into markdown.

## Assumptions

- Focused on pdf to markdown conversion accuracy / edge cases, instead of structured extraction (I'd consider that a slightly different workflow).
- I saw that there was a `use_llm` mode which helps with tables and multi-page cases, so when testing my rules engine, I compared my input files across with `default settings`, `use_llm enabled`, and `rules_engine enabled` to see if the latter guaranteed outcomes in that specific scenario.

## Use Cases

Because we didn't have a mix of user stories, I imagined myself as a user based on prior work with scientific PDFs. 

### Accurate Conversion for Downstream RAG

In RAG applications that rely on full-text, you might consider different chunking strategies for your text. All of that is based on the assumption that your input has text in the right order, and that things like metadata in a gutter, footer, figure tags don't get in the way and add noise to your data.

Applying `marker` on a scientific PDF to markdown is convenient, but given the variance in PDF formatting across publishers / journals, we need to ensure that markdown conversion is accurate.

Two edge cases I considered:

#### Removing irrelevant text to minimize file sizes and create a consistent / clean output
Some papers have a lot of text that's totally not useful to your use case, e.g. funding info, citation formatting, and other metadata, in the gutter. You can see this on the left in PLoS papers.

- [plos_ex_1.pdf](https://github.com/user-attachments/files/20746523/plos_ex_1.pdf)
- [plos_ex_2.pdf](https://github.com/user-attachments/files/20746524/plos_ex_2.pdf)

When converted by `marker`, the output looks like this:
[plos_ex_1_llm_marker.md](https://github.com/user-attachments/files/20746544/plos_ex_1.md)

If you're wondering why not just leave it as is and process the markdown later to strip out the first bit before the abstract, the issue is what happens on page 2 when the gutter continues from page 1 and disrupts the author's writing from the introduction section.

In this case, you can safely prune anything in the left gutter across all pages, so I added a rule called `layout.exclude_gutter` that lets you specify the side and width (as a ratio) to omit, if you know ahead of time that all PDFs have that consistently. See below for implementation notes.

> $ marker_single local_notes/sample_files/plos_ex_1.pdf --output_dir <OUTPUT_DIR> --rules examples/plos_paper.yaml

The processed output using the new rule:
[plos_ex_1_with_gutter_rule.md](https://github.com/user-attachments/files/20746546/plos_ex_1.md)

#### Ensuring that the ordering of text in the final markdown is correct
i.e. when there's weird groupings / layouts. I think to some degree this one could be fixed in `surya`, but I wanted to see if I could mess with it at the `marker` level to play whackamole

### 