### PR TITLE
Fix LLM query retry logic and unnecessary sleeping

### DIFF
--- a/marker/services/claude.py
+++ b/marker/services/claude.py
@@ -130,11 +130,18 @@ Respond only with the JSON schema, nothing else.  Do not include ```json, ```,  
                 return self.validate_response(response_text, response_schema)
             except (RateLimitError, APITimeoutError) as e:
                 # Rate limit exceeded
-                wait_time = tries * self.retry_wait_time
-                logger.warning(
-                    f"Rate limit error: {e}. Retrying in {wait_time} seconds... (Attempt {tries}/{total_tries})"
-                )
-                time.sleep(wait_time)
+                if tries == total_tries:
+                    # Last attempt failed. Give up
+                    logger.error(
+                        f"Rate limit error: {e}. Max retries reached. Giving up. (Attempt {tries}/{total_tries})",
+                    )
+                    break
+                else:
+                    wait_time = tries * self.retry_wait_time
+                    logger.warning(
+                        f"Rate limit error: {e}. Retrying in {wait_time} seconds... (Attempt {tries}/{total_tries})",
+                    )
+                    time.sleep(wait_time)
             except Exception as e:
                 logger.error(f"Error during Claude API call: {e}")
                 break

--- a/marker/services/claude.py
+++ b/marker/services/claude.py
@@ -115,8 +115,8 @@ Respond only with the JSON schema, nothing else.  Do not include ```json, ```,  
             }
         ]
 
-        tries = 0
-        while tries < max_retries:
+        total_tries = max_retries + 1
+        for tries in range(1, total_tries + 1):
             try:
                 response = client.messages.create(
                     system=system_prompt,
@@ -130,10 +130,9 @@ Respond only with the JSON schema, nothing else.  Do not include ```json, ```,  
                 return self.validate_response(response_text, response_schema)
             except (RateLimitError, APITimeoutError) as e:
                 # Rate limit exceeded
-                tries += 1
                 wait_time = tries * self.retry_wait_time
                 logger.warning(
-                    f"Rate limit error: {e}. Retrying in {wait_time} seconds... (Attempt {tries}/{max_retries})"
+                    f"Rate limit error: {e}. Retrying in {wait_time} seconds... (Attempt {tries}/{total_tries})"
                 )
                 time.sleep(wait_time)
             except Exception as e:

--- a/marker/services/gemini.py
+++ b/marker/services/gemini.py
@@ -75,11 +75,18 @@ class BaseGeminiService(BaseService):
             except APIError as e:
                 if e.code in [429, 443, 503]:
                     # Rate limit exceeded
-                    wait_time = tries * self.retry_wait_time
-                    logger.warning(
-                        f"APIError: {e}. Retrying in {wait_time} seconds... (Attempt {tries}/{total_tries})"
-                    )
-                    time.sleep(wait_time)
+                    if tries == total_tries:
+                        # Last attempt failed. Give up
+                        logger.error(
+                            f"APIError: {e}. Max retries reached. Giving up. (Attempt {tries}/{total_tries})",
+                        )
+                        break
+                    else:
+                        wait_time = tries * self.retry_wait_time
+                        logger.warning(
+                            f"APIError: {e}. Retrying in {wait_time} seconds... (Attempt {tries}/{total_tries})",
+                        )
+                        time.sleep(wait_time)
                 else:
                     logger.error(f"APIError: {e}")
                     break

--- a/marker/services/gemini.py
+++ b/marker/services/gemini.py
@@ -53,8 +53,8 @@ class BaseGeminiService(BaseService):
             for img in image
         ]
 
-        tries = 0
-        while tries < max_retries:
+        total_tries = max_retries + 1
+        for tries in range(1, total_tries + 1):
             try:
                 responses = client.models.generate_content(
                     model=self.gemini_model_name,
@@ -75,10 +75,9 @@ class BaseGeminiService(BaseService):
             except APIError as e:
                 if e.code in [429, 443, 503]:
                     # Rate limit exceeded
-                    tries += 1
                     wait_time = tries * self.retry_wait_time
                     logger.warning(
-                        f"APIError: {e}. Retrying in {wait_time} seconds... (Attempt {tries}/{max_retries})"
+                        f"APIError: {e}. Retrying in {wait_time} seconds... (Attempt {tries}/{total_tries})"
                     )
                     time.sleep(wait_time)
                 else:

--- a/marker/services/openai.py
+++ b/marker/services/openai.py
@@ -101,11 +101,18 @@ class OpenAIService(BaseService):
                 return json.loads(response_text)
             except (APITimeoutError, RateLimitError) as e:
                 # Rate limit exceeded
-                wait_time = tries * self.retry_wait_time
-                logger.warning(
-                    f"Rate limit error: {e}. Retrying in {wait_time} seconds... (Attempt {tries}/{total_tries})"
-                )
-                time.sleep(wait_time)
+                if tries == total_tries:
+                    # Last attempt failed. Give up
+                    logger.error(
+                        f"Rate limit error: {e}. Max retries reached. Giving up. (Attempt {tries}/{total_tries})",
+                    )
+                    break
+                else:
+                    wait_time = tries * self.retry_wait_time
+                    logger.warning(
+                        f"Rate limit error: {e}. Retrying in {wait_time} seconds... (Attempt {tries}/{total_tries})",
+                    )
+                    time.sleep(wait_time)
             except Exception as e:
                 logger.error(f"OpenAI inference failed: {e}")
                 break

--- a/marker/services/openai.py
+++ b/marker/services/openai.py
@@ -82,8 +82,8 @@ class OpenAIService(BaseService):
             }
         ]
 
-        tries = 0
-        while tries < max_retries:
+        total_tries = max_retries + 1
+        for tries in range(1, total_tries + 1):
             try:
                 response = client.beta.chat.completions.parse(
                     extra_headers={
@@ -101,10 +101,9 @@ class OpenAIService(BaseService):
                 return json.loads(response_text)
             except (APITimeoutError, RateLimitError) as e:
                 # Rate limit exceeded
-                tries += 1
                 wait_time = tries * self.retry_wait_time
                 logger.warning(
-                    f"Rate limit error: {e}. Retrying in {wait_time} seconds... (Attempt {tries}/{max_retries})"
+                    f"Rate limit error: {e}. Retrying in {wait_time} seconds... (Attempt {tries}/{total_tries})"
                 )
                 time.sleep(wait_time)
             except Exception as e:


### PR DESCRIPTION
This PR addresses two issues in the LLM querying logic (for Gemini/OpenAI/Claude):

- Corrects an off-by-one error in the retry loop: the code previously retried only `max_retries - 1` times after the initial attempt.
- Prevents logging "Retrying in X seconds..." and sleeping when no further retries will occur.

Fixes #771 