### PR TITLE
fix: handles when block config is none

### DIFF
--- a/marker/schema/blocks/pagefooter.py
+++ b/marker/schema/blocks/pagefooter.py
@@ -12,7 +12,7 @@ class PageFooter(Block):
     html: str | None = None
 
     def assemble_html(self, document, child_blocks, parent_structure, block_config):
-        if block_config.get("keep_pagefooter_in_output"):
+        if block_config and block_config.get("keep_pagefooter_in_output"):
             self.ignore_for_output = False
 
         if self.html and not self.ignore_for_output:

--- a/marker/schema/blocks/pageheader.py
+++ b/marker/schema/blocks/pageheader.py
@@ -12,7 +12,7 @@ class PageHeader(Block):
     html: str | None = None
 
     def assemble_html(self, document, child_blocks, parent_structure, block_config):
-        if block_config.get("keep_pageheader_in_output"):
+        if block_config and block_config.get("keep_pageheader_in_output"):
             self.ignore_for_output = False
 
         if self.html and not self.ignore_for_output:


### PR DESCRIPTION
if `block_config` is None, this will throw
`NoneType has no attribute get`