### PR TITLE
feat(readme.md): Add save_output function example in **use from python**

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,9 @@ converter = PdfConverter(
 )
 rendered = converter("FILEPATH")
 text, _, images = text_from_rendered(rendered)
+
+# Saving markdown, json metadata, and images to a directory
+save_output(rendered=rendered, output_dir="your_output_dir", fname_base: "")
 ```
 
 `rendered` will be a pydantic basemodel with different properties depending on the output type requested.  With markdown output (default), you'll have the properties `markdown`, `metadata`, and `images`.  For json output, you'll have `children`, `block_type`, and `metadata`.


### PR DESCRIPTION
**Add save_output example for saving the markdown, metadata json, and images using python code.**

I have read the CLA Document and I hereby sign the CLA