### PR TITLE
Table Hotfixes

### DIFF
--- a/marker/processors/table.py
+++ b/marker/processors/table.py
@@ -568,7 +568,7 @@ class TableProcessor(BaseProcessor):
         assert len(detection_results) == len(ocr_idxs), "Every OCRed table requires a text detection result"
 
         for idx, table_detection_result in zip(ocr_idxs, detection_results):
-            self.align_table_cells(table_blocks[idx]["table_image"], tables[idx], table_detection_result)
+            self.align_table_cells(tables[idx], table_detection_result)
 
         ocr_polys = []
         for ocr_idx in ocr_idxs:

--- a/marker/processors/table.py
+++ b/marker/processors/table.py
@@ -3,9 +3,10 @@ from collections import defaultdict
 from copy import deepcopy
 from typing import Annotated, List
 from collections import Counter
-from PIL import Image
+from PIL import Image, ImageDraw
 
 from ftfy import fix_text
+from surya.detection import DetectionPredictor, TextDetectionResult
 from surya.recognition import RecognitionPredictor, OCRResult, TextLine
 from surya.table_rec import TableRecPredictor
 from surya.table_rec.schema import TableResult, TableCell as SuryaTableCell
@@ -33,6 +34,11 @@ class TableProcessor(BaseProcessor):
     table_rec_batch_size: Annotated[
         int,
         "The batch size to use for the table recognition model.",
+        "Default is None, which will use the default batch size for the model.",
+    ] = None
+    detection_batch_size: Annotated[
+        int,
+        "The batch size to use for the table detection model.",
         "Default is None, which will use the default batch size for the model.",
     ] = None
     recognition_batch_size: Annotated[
@@ -64,12 +70,14 @@ class TableProcessor(BaseProcessor):
         self,
         recognition_model: RecognitionPredictor,
         table_rec_model: TableRecPredictor,
+        detection_model: DetectionPredictor,
         config=None,
     ):
         super().__init__(config)
 
         self.recognition_model = recognition_model
         self.table_rec_model = table_rec_model
+        self.detection_model = detection_model
 
     def __call__(self, document: Document):
         filepath = document.filepath  # Path to original pdf file
@@ -105,6 +113,7 @@ class TableProcessor(BaseProcessor):
             [t["table_image"] for t in table_data],
             batch_size=self.get_table_rec_batch_size(),
         )
+        assert len(tables) == len(table_data), "Number of table results should match the number of tables"
 
         # Assign cell text if we don't need OCR
         # We do this at a line level
@@ -479,24 +488,100 @@ class TableProcessor(BaseProcessor):
                 "Number of tables and table inputs must match"
             )
 
-    def needs_ocr(self, tables: List[TableResult]):
+    def align_table_cells(self, table: TableResult, table_detection_result: TextDetectionResult):
+        table_cells = table.cells
+        table_text_lines = table_detection_result.bboxes
+
+        text_line_bboxes = [t.bbox for t in table_text_lines]
+        table_cell_bboxes = [c.bbox for c in table_cells]
+
+        intersection_matrix = matrix_intersection_area(
+            text_line_bboxes, table_cell_bboxes
+        )
+
+        # Map cells -> list of assigned text lines
+        cell_text = defaultdict(list)
+        for text_line_idx, table_text_line in enumerate(table_text_lines):
+            intersections = intersection_matrix[text_line_idx]
+            if intersections.sum() == 0:
+                continue
+            max_intersection = intersections.argmax()
+            cell_text[max_intersection].append(table_text_line)
+
+        # Adjust cell polygons in place
+        for cell_idx, cell in enumerate(table_cells):
+
+            # all intersecting lines
+            intersecting_line_indices = [
+                i for i, area in enumerate(intersection_matrix[:, cell_idx]) if area > 0
+            ]
+            if not intersecting_line_indices:
+                continue
+
+            assigned_lines = cell_text.get(cell_idx, [])
+            # Expand to fit assigned lines - **Only in the y direction**
+            for assigned_line in assigned_lines:
+                x1 = cell.bbox[0]
+                x2 = cell.bbox[2]
+                y1 = min(cell.bbox[1], assigned_line.bbox[1])
+                y2 = max(cell.bbox[3], assigned_line.bbox[3])
+                cell.polygon = [[x1, y1], [x2, y1], [x2, y2], [x1, y2]]
+
+            # Clear out non-assigned lines
+            non_assigned_lines = [
+                table_text_lines[i] for i in intersecting_line_indices if table_text_lines[i] not in cell_text.get(cell_idx, [])
+            ]
+            if non_assigned_lines:
+                # Find top-most and bottom-most non-assigned boxes
+                top_box = min(non_assigned_lines, key=lambda l: l.bbox[1])    # smallest y0
+                bottom_box = max(non_assigned_lines, key=lambda l: l.bbox[3]) # largest y1
+
+                # Current cell bbox (from polygon)
+                x0, y0, x1, y1 = cell.bbox
+
+                # Adjust y-limits based on non-assigned boxes
+                new_y0 = max(y0, top_box.bbox[3])    # top moves down
+                new_y1 = min(y1, bottom_box.bbox[1]) # bottom moves up
+
+                if new_y0 < new_y1:
+                    # Replace polygon with a new shrunken rectangle
+                    cell.polygon = [
+                        [x0, new_y0],
+                        [x1, new_y0],
+                        [x1, new_y1],
+                        [x0, new_y1],
+                    ]
+
+    def needs_ocr(self, tables: List[TableResult], table_blocks: List[dict]):
         ocr_tables = []
-        ocr_polys = []
         ocr_idxs = []
-        for j, result in enumerate(tables):
-            table_cells: List[SuryaTableCell] = result.cells
-            if any([tc.text_lines is None for tc in table_cells]):
-                ocr_tables.append(result)
-                polys = [tc for tc in table_cells if tc.text_lines is None]
-                ocr_polys.append(polys)
+        for j, (table_result, table_block) in enumerate(zip(tables, table_blocks)):
+            table_cells: List[SuryaTableCell] = table_result.cells
+            if table_block["ocr_block"] and any([tc.text_lines is None for tc in table_cells]):
+                ocr_tables.append(table_result)
                 ocr_idxs.append(j)
+
+        detection_results: List[TextDetectionResult] = self.detection_model(
+            images=[table_blocks[i]["table_image"] for i in ocr_idxs],
+            batch_size=self.get_detection_batch_size()
+        )
+        assert len(detection_results) == len(ocr_idxs), "Every OCRed table requires a text detection result"
+
+        for idx, table_detection_result in zip(ocr_idxs, detection_results):
+            self.align_table_cells(table_blocks[idx]["table_image"], tables[idx], table_detection_result)
+
+        ocr_polys = []
+        for ocr_idx in ocr_idxs:
+            table_cells = tables[ocr_idx].cells
+            polys = [tc for tc in table_cells if tc.text_lines is None]
+            ocr_polys.append(polys)
         return ocr_tables, ocr_polys, ocr_idxs
 
     def get_ocr_results(self, table_images: List[Image.Image], ocr_polys: List[List[SuryaTableCell]]):
         ocr_polys_blank = []
 
         for table_image, polys in zip(table_images, ocr_polys):
-            table_polys_blank = [is_blank_image(table_image.crop(poly.bbox), poly.polygon) for poly in polys]
+            table_polys_blank = [(poly.height < 6 or is_blank_image(table_image.crop(poly.bbox), poly.polygon)) for poly in polys]
             ocr_polys_blank.append(table_polys_blank)
                 
         filtered_polys = []
@@ -548,7 +633,7 @@ class TableProcessor(BaseProcessor):
         return ocr_results
 
     def assign_ocr_lines(self, tables: List[TableResult], table_blocks: list):
-        ocr_tables, ocr_polys, ocr_idxs = self.needs_ocr(tables)
+        ocr_tables, ocr_polys, ocr_idxs = self.needs_ocr(tables, table_blocks)
         det_images = [
             t["table_image"] for i, t in enumerate(table_blocks) if i in ocr_idxs
         ]
@@ -589,3 +674,10 @@ class TableProcessor(BaseProcessor):
         elif settings.TORCH_DEVICE_MODEL == "cuda":
             return 48
         return 32
+
+    def get_detection_batch_size(self):
+        if self.detection_batch_size is not None:
+            return self.detection_batch_size
+        elif settings.TORCH_DEVICE_MODEL == "cuda":
+            return 10
+        return 4

--- a/tests/builders/test_garbled_pdf.py
+++ b/tests/builders/test_garbled_pdf.py
@@ -7,7 +7,7 @@ from marker.schema import BlockTypes
 
 
 @pytest.mark.filename("water_damage.pdf")
-def test_garbled_pdf(pdf_document, recognition_model, table_rec_model):
+def test_garbled_pdf(pdf_document, recognition_model, table_rec_model, detection_model):
     assert pdf_document.pages[0].structure[0] == "/page/0/Table/0"
 
     table_block = pdf_document.pages[0].get_block(pdf_document.pages[0].structure[0])
@@ -18,7 +18,7 @@ def test_garbled_pdf(pdf_document, recognition_model, table_rec_model):
     assert table_cell.block_type == BlockTypes.Line
 
     # We don't OCR in the initial pass, only with the TableProcessor
-    processor = TableProcessor(recognition_model, table_rec_model)
+    processor = TableProcessor(recognition_model, table_rec_model, detection_model)
     processor(pdf_document)
 
     table = pdf_document.pages[0].contained_blocks(pdf_document, (BlockTypes.Table,))[0]

--- a/tests/processors/test_llm_processors.py
+++ b/tests/processors/test_llm_processors.py
@@ -39,14 +39,14 @@ def test_llm_form_processor_no_cells(pdf_document, llm_service):
 
 @pytest.mark.filename("form_1040.pdf")
 @pytest.mark.config({"page_range": [0]})
-def test_llm_form_processor(pdf_document, table_rec_model, recognition_model):
+def test_llm_form_processor(pdf_document, table_rec_model, recognition_model, detection_model):
     corrected_html = "<em>This is corrected markdown.</em>\n" * 100
     corrected_html = "<p>" + corrected_html.strip() + "</p>\n"
 
     mock_cls = Mock()
     mock_cls.return_value = {"corrected_html": corrected_html}
 
-    cell_processor = TableProcessor(recognition_model, table_rec_model)
+    cell_processor = TableProcessor(recognition_model, table_rec_model, detection_model)
     cell_processor(pdf_document)
 
     config = {"use_llm": True, "gemini_api_key": "test"}
@@ -61,7 +61,7 @@ def test_llm_form_processor(pdf_document, table_rec_model, recognition_model):
 
 @pytest.mark.filename("table_ex2.pdf")
 @pytest.mark.config({"page_range": [0]})
-def test_llm_table_processor(pdf_document, table_rec_model, recognition_model):
+def test_llm_table_processor(pdf_document, table_rec_model, recognition_model, detection_model):
     corrected_html = """
 <table>
     <tr>
@@ -88,7 +88,7 @@ def test_llm_table_processor(pdf_document, table_rec_model, recognition_model):
     mock_cls = Mock()
     mock_cls.return_value = {"corrected_html": corrected_html}
 
-    cell_processor = TableProcessor(recognition_model, table_rec_model)
+    cell_processor = TableProcessor(recognition_model, table_rec_model, detection_model)
     cell_processor(pdf_document)
 
     processor = LLMTableProcessor(mock_cls, {"use_llm": True, "gemini_api_key": "test"})

--- a/tests/processors/test_table_merge.py
+++ b/tests/processors/test_table_merge.py
@@ -8,14 +8,14 @@ from marker.schema import BlockTypes
 
 
 @pytest.mark.filename("table_ex2.pdf")
-def test_llm_table_processor_nomerge(pdf_document, table_rec_model, recognition_model, mocker):
+def test_llm_table_processor_nomerge(pdf_document, table_rec_model, recognition_model, detection_model, mocker):
     mock_cls = Mock()
     mock_cls.return_value = {
         "merge": "true",
         "direction": "right"
     }
 
-    cell_processor = TableProcessor(recognition_model, table_rec_model)
+    cell_processor = TableProcessor(recognition_model, table_rec_model, detection_model)
     cell_processor(pdf_document)
 
     tables = pdf_document.contained_blocks((BlockTypes.Table,))

--- a/tests/processors/test_table_processor.py
+++ b/tests/processors/test_table_processor.py
@@ -10,9 +10,9 @@ from marker.schema.blocks import TableCell
 
 @pytest.mark.config({"page_range": [5]})
 def test_table_processor(
-    pdf_document, recognition_model, table_rec_model
+    pdf_document, recognition_model, table_rec_model, detection_model
 ):
-    processor = TableProcessor(recognition_model, table_rec_model)
+    processor = TableProcessor(recognition_model, table_rec_model, detection_model)
     processor(pdf_document)
 
     for block in pdf_document.pages[0].children:
@@ -32,14 +32,14 @@ def test_table_processor(
 @pytest.mark.filename("table_ex.pdf")
 @pytest.mark.config({"page_range": [0], "force_ocr": True})
 def test_avoid_double_ocr(
-    pdf_document, recognition_model, table_rec_model
+    pdf_document, recognition_model, table_rec_model, detection_model
 ):
     tables = pdf_document.contained_blocks((BlockTypes.Table,))
     lines = tables[0].contained_blocks(pdf_document, (BlockTypes.Line,))
     assert len(lines) == 0
 
     processor = TableProcessor(
-        recognition_model, table_rec_model, config={"force_ocr": True}
+        recognition_model, table_rec_model, detection_model, config={"force_ocr": True}
     )
     processor(pdf_document)
 
@@ -58,7 +58,7 @@ def test_overlap_blocks(
         pdf_document
     )
 
-    processor = TableProcessor(recognition_model, table_rec_model)
+    processor = TableProcessor(recognition_model, table_rec_model, detection_model)
     processor(pdf_document)
 
     assert "Cascading, and the Auxiliary Problem Principle" in page.raw_text(
@@ -68,8 +68,8 @@ def test_overlap_blocks(
 
 @pytest.mark.filename("pres.pdf")
 @pytest.mark.config({"page_range": [4]})
-def test_ocr_table(pdf_document, recognition_model, table_rec_model):
-    processor = TableProcessor(recognition_model, table_rec_model)
+def test_ocr_table(pdf_document, recognition_model, table_rec_model, detection_model):
+    processor = TableProcessor(recognition_model, table_rec_model, detection_model)
     processor(pdf_document)
 
     renderer = MarkdownRenderer()
@@ -78,8 +78,8 @@ def test_ocr_table(pdf_document, recognition_model, table_rec_model):
 
 
 @pytest.mark.config({"page_range": [11]})
-def test_split_rows(pdf_document, recognition_model, table_rec_model):
-    processor = TableProcessor(recognition_model, table_rec_model)
+def test_split_rows(pdf_document, recognition_model, table_rec_model, detection_model):
+    processor = TableProcessor(recognition_model, table_rec_model, detection_model)
     processor(pdf_document)
 
     table = pdf_document.contained_blocks((BlockTypes.Table,))[-1]


### PR DESCRIPTION
Minor fixes for table processing to fallback on when table rec is bad:
- Expand table cells to include all intersecting lines
- Cut out non-intersecting lines from table cells
- Expand bboxes to match what we do in surya which seems to improve perf on average