### PR TITLE
Fix typo in superscript/subscript condition check

### DIFF
--- a/marker/providers/pdf.py
+++ b/marker/providers/pdf.py
@@ -244,7 +244,7 @@ class PdfProvider(BaseProvider):
                         superscript = span.get("superscript", False)
                         subscript = span.get("subscript", False)
                         text = self.normalize_spaces(fix_text(span["text"]))
-                        if superscript or superscript:
+                        if superscript or subscript:
                             text = text.strip()
 
                         spans.append(


### PR DESCRIPTION
Fix condition that incorrectly checked 'superscript or superscript' instead of 'superscript or subscript' in PDF text processing. This typo would prevent subscript text from having whitespace trimmed, causing inconsistent formatting between superscript and subscript spans. Detected using Claude Code.