### PR TITLE
Implement page-level pipelining for PDF conversion

### DIFF
--- a/marker/builders/document.py
+++ b/marker/builders/document.py
@@ -1,4 +1,5 @@
-from typing import Annotated
+from concurrent.futures import ThreadPoolExecutor
+from typing import Annotated, Iterable, List
 
 from marker.builders import BaseBuilder
 from marker.builders.layout import LayoutBuilder
@@ -28,26 +29,136 @@ class DocumentBuilder(BaseBuilder):
         "Disable OCR processing.",
     ] = False
 
-    def __call__(self, provider: PdfProvider, layout_builder: LayoutBuilder, line_builder: LineBuilder, ocr_builder: OcrBuilder):
+    page_pipeline_chunk_size: Annotated[
+        int,
+        "The number of pages to batch together when running the page-level pipeline.",
+    ] = 12
+    page_pipeline_workers: Annotated[
+        int,
+        "The number of worker threads to use for the page pipeline stages.",
+    ] = 3
+
+    def __call__(
+        self,
+        provider: PdfProvider,
+        layout_builder: LayoutBuilder,
+        line_builder: LineBuilder,
+        ocr_builder: OcrBuilder,
+    ):
         document = self.build_document(provider)
-        layout_builder(document, provider)
-        line_builder(document, provider)
-        if not self.disable_ocr:
-            ocr_builder(document, provider)
+
+        if not document.pages:
+            return document
+
+        # Fall back to sequential execution if pipeline disabled via configuration
+        if self.page_pipeline_chunk_size <= 0 or self.page_pipeline_workers <= 0:
+            self._load_images_for_pages(document.pages, provider)
+            layout_builder.process_pages(document, provider, document.pages)
+            layout_builder.expand_layout_blocks(document)
+            line_builder.process_pages(document, provider, document.pages)
+            if not self.disable_ocr:
+                ocr_builder.process_pages(document, provider, document.pages)
+            return document
+
+        page_chunks = list(self._chunk_pages(document.pages, self.page_pipeline_chunk_size))
+
+        def run_layout(pages: List[PageGroup]):
+            layout_builder.process_pages(document, provider, pages)
+            return pages
+
+        def run_line(pages: List[PageGroup]):
+            line_builder.process_pages(document, provider, pages)
+            for page in pages:
+                page.lowres_image = None
+            return pages
+
+        def run_ocr(pages: List[PageGroup]):
+            ocr_builder.process_pages(document, provider, pages)
+            return pages
+
+        layout_futures = {}
+        line_futures = {}
+        ocr_futures = {}
+
+        with ThreadPoolExecutor(max_workers=self.page_pipeline_workers) as executor:
+            for idx, chunk_pages in enumerate(page_chunks):
+                self._load_images_for_pages(chunk_pages, provider)
+                layout_future = executor.submit(run_layout, chunk_pages)
+                layout_futures[idx] = (layout_future, chunk_pages)
+
+                prev_idx = idx - 1
+                if prev_idx >= 0 and prev_idx in layout_futures and prev_idx not in line_futures:
+                    prev_future, prev_pages = layout_futures[prev_idx]
+                    prev_future.result()
+                    line_futures[prev_idx] = (
+                        executor.submit(run_line, prev_pages),
+                        prev_pages,
+                    )
+
+                prev_prev_idx = idx - 2
+                if (
+                    not self.disable_ocr
+                    and prev_prev_idx >= 0
+                    and prev_prev_idx in line_futures
+                    and prev_prev_idx not in ocr_futures
+                ):
+                    prev_line_future, prev_line_pages = line_futures[prev_prev_idx]
+                    prev_line_future.result()
+                    ocr_futures[prev_prev_idx] = executor.submit(
+                        run_ocr, prev_line_pages
+                    )
+
+            # Ensure remaining stages are scheduled after the main loop completes
+            for idx, (layout_future, pages) in layout_futures.items():
+                if idx not in line_futures:
+                    layout_future.result()
+                    line_futures[idx] = (
+                        executor.submit(run_line, pages),
+                        pages,
+                    )
+
+            if not self.disable_ocr:
+                for idx, (line_future, pages) in line_futures.items():
+                    if idx not in ocr_futures:
+                        line_future.result()
+                        ocr_futures[idx] = executor.submit(run_ocr, pages)
+
+            # Wait for all scheduled work to complete before returning
+            for layout_future, _ in layout_futures.values():
+                layout_future.result()
+            for line_future, _ in line_futures.values():
+                line_future.result()
+            if not self.disable_ocr:
+                for ocr_future in ocr_futures.values():
+                    ocr_future.result()
+
+        layout_builder.expand_layout_blocks(document)
         return document
 
     def build_document(self, provider: PdfProvider):
         PageGroupClass: PageGroup = get_block_class(BlockTypes.Page)
-        lowres_images = provider.get_images(provider.page_range, self.lowres_image_dpi)
-        highres_images = provider.get_images(provider.page_range, self.highres_image_dpi)
         initial_pages = [
             PageGroupClass(
                 page_id=p,
-                lowres_image=lowres_images[i],
-                highres_image=highres_images[i],
+                lowres_image=None,
+                highres_image=None,
                 polygon=provider.get_page_bbox(p),
                 refs=provider.get_page_refs(p)
             ) for i, p in enumerate(provider.page_range)
         ]
         DocumentClass: Document = get_block_class(BlockTypes.Document)
         return DocumentClass(filepath=provider.filepath, pages=initial_pages)
+
+    def _chunk_pages(self, pages: List[PageGroup], chunk_size: int) -> Iterable[List[PageGroup]]:
+        for idx in range(0, len(pages), chunk_size):
+            yield pages[idx : idx + chunk_size]
+
+    def _load_images_for_pages(self, pages: List[PageGroup], provider: PdfProvider):
+        page_ids = [page.page_id for page in pages]
+        lowres_images = provider.get_images(page_ids, self.lowres_image_dpi)
+        highres_images = provider.get_images(page_ids, self.highres_image_dpi)
+        for page, lowres_image, highres_image in zip(
+            pages, lowres_images, highres_images
+        ):
+            page.lowres_image = lowres_image
+            page.highres_image = highres_image

--- a/marker/builders/layout.py
+++ b/marker/builders/layout.py
@@ -49,13 +49,20 @@ class LayoutBuilder(BaseBuilder):
         super().__init__(config)
 
     def __call__(self, document: Document, provider: PdfProvider):
+        self.process_pages(document, provider, document.pages)
+        self.expand_layout_blocks(document)
+
+    def process_pages(
+        self, document: Document, provider: PdfProvider, pages: List[PageGroup]
+    ):
+        if not pages:
+            return
         if self.force_layout_block is not None:
             # Assign the full content of every page to a single layout type
-            layout_results = self.forced_layout(document.pages)
+            layout_results = self.forced_layout(pages)
         else:
-            layout_results = self.surya_layout(document.pages)
-        self.add_blocks_to_pages(document.pages, layout_results)
-        self.expand_layout_blocks(document)
+            layout_results = self.surya_layout(pages)
+        self.add_blocks_to_pages(pages, layout_results)
 
     def get_batch_size(self):
         if self.layout_batch_size is not None:

--- a/marker/builders/ocr.py
+++ b/marker/builders/ocr.py
@@ -80,7 +80,18 @@ class OcrBuilder(BaseBuilder):
         self.recognition_model = recognition_model
 
     def __call__(self, document: Document, provider: PdfProvider):
-        pages_to_ocr = [page for page in document.pages if page.text_extraction_method == 'surya']
+        self.process_pages(document, provider, document.pages)
+
+    def process_pages(
+        self, document: Document, provider: PdfProvider, pages: List[PageGroup]
+    ):
+        if not pages:
+            return
+        pages_to_ocr = [
+            page for page in pages if page.text_extraction_method == "surya"
+        ]
+        if not pages_to_ocr:
+            return
         ocr_page_images, block_polygons, block_ids, block_original_texts = (
             self.get_ocr_images_polygons_ids(document, pages_to_ocr, provider)
         )


### PR DESCRIPTION
## Summary
- add configurable page-level pipelining to the document builder to overlap layout, line, and OCR stages
- load page images lazily per chunk and reuse new `process_pages` helpers across builders
- expose chunked processing APIs on layout, line, and OCR builders for reuse by the pipeline

## Testing
- `pytest tests/builders -q` *(fails: requires downloading datalab-to/pdfs from Hugging Face, which is blocked in this environment)*

------
https://chatgpt.com/codex/tasks/task_b_68e53970c6e48322bdac69082ad272fd