### PR TITLE
fix: keep short paragraph-final lines that is_blank_image misclassified

### DIFF
--- a/marker/utils/image.py
+++ b/marker/utils/image.py
@@ -21,6 +21,15 @@ def is_blank_image(
             return True
 
     gray = cv2.cvtColor(image, cv2.COLOR_RGB2GRAY)
+    # adaptiveThreshold blockSize is 31. On crops smaller than that — almost
+    # always the last one- or two-word line of a paragraph — the 7x7 blur plus
+    # a 31-pixel window wipes the ink and the line is deleted as "blank".
+    if min(gray.shape[:2]) < 31:
+        _, binarized = cv2.threshold(
+            gray, 0, 255, cv2.THRESH_BINARY_INV + cv2.THRESH_OTSU
+        )
+        return not bool(binarized.any())
+
     gray = cv2.GaussianBlur(gray, (7, 7), 0)
 
     # Adaptive threshold (inverse for text as white)

--- a/tests/test_blank_image.py
+++ b/tests/test_blank_image.py
@@ -1,0 +1,33 @@
+import numpy as np
+from PIL import Image
+
+from marker.utils.image import is_blank_image
+
+
+def _rgb(array: np.ndarray) -> Image.Image:
+    return Image.fromarray(array.astype(np.uint8), mode="RGB")
+
+
+def test_small_text_crop_is_not_blank():
+    """Widow-line crops are smaller than the adaptive-threshold window."""
+    crop = np.full((8, 22, 3), 255, dtype=np.uint8)
+    crop[2:6, 3:7] = 20
+    crop[2:6, 10:14] = 20
+    crop[2:6, 16:20] = 20
+    assert is_blank_image(_rgb(crop)) is False
+
+
+def test_small_white_crop_is_blank():
+    crop = np.full((8, 22, 3), 255, dtype=np.uint8)
+    assert is_blank_image(_rgb(crop)) is True
+
+
+def test_large_text_crop_still_detected():
+    crop = np.full((64, 64, 3), 255, dtype=np.uint8)
+    crop[16:48, 16:48] = 0
+    assert is_blank_image(_rgb(crop)) is False
+
+
+def test_large_white_crop_is_blank():
+    crop = np.full((64, 64, 3), 255, dtype=np.uint8)
+    assert is_blank_image(_rgb(crop)) is True


### PR DESCRIPTION
Fixes #1071

## Summary
- Widow-line crops are smaller than the adaptiveThreshold window.
- Use Otsu on crops with min dimension < 31 so real ink is kept.

## Testing
- PYTHONPATH=. pytest tests/test_blank_image.py --noconftest  (4 passed)