### PR TITLE
test: skip gated PDF fixtures when unavailable

### DIFF
--- a/tests/builders/test_overriding.py
+++ b/tests/builders/test_overriding.py
@@ -19,13 +19,14 @@ class NewLine(Line):
     pass
 
 
-@pytest.mark.config({
-    "page_range": [0],
-    "override_map": {BlockTypes.SectionHeader: NewSectionHeader}
-})
+@pytest.mark.config(
+    {"page_range": [0], "override_map": {BlockTypes.SectionHeader: NewSectionHeader}}
+)
 def test_overriding(pdf_document: Document):
-    assert pdf_document.pages[0]\
-        .get_block(pdf_document.pages[0].structure[0]).__class__ == NewSectionHeader
+    assert (
+        pdf_document.pages[0].get_block(pdf_document.pages[0].structure[0]).__class__
+        == NewSectionHeader
+    )
 
 
 def get_lines(pdf: str, config=None):
@@ -36,11 +37,9 @@ def get_lines(pdf: str, config=None):
     return provider.get_page_lines(0)
 
 
+@pytest.mark.usefixtures("pdf_dataset")
 def test_overriding_mp():
-    config = {
-        "page_range": [0],
-        "override_map": {BlockTypes.Line: NewLine}
-    }
+    config = {"page_range": [0], "override_map": {BlockTypes.Line: NewLine}}
 
     pdf_list = ["adversarial.pdf", "adversarial_rot.pdf"]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,8 @@
 import tempfile
 from typing import Dict, Type
 
-from PIL import Image, ImageDraw
-
-import datasets
 import pytest
+from PIL import Image, ImageDraw
 
 from marker.builders.document import DocumentBuilder
 from marker.builders.layout import LayoutBuilder
@@ -22,6 +20,7 @@ from marker.renderers.markdown import MarkdownRenderer
 from marker.renderers.json import JSONRenderer
 from marker.schema.registry import register_block_class
 from marker.util import classes_to_strings, strings_to_classes
+from tests.utils import PdfFixtureDatasetUnavailable, load_pdf_fixture_dataset
 
 
 @pytest.fixture(scope="session")
@@ -63,9 +62,16 @@ def config(request):
     return config
 
 
+def load_or_skip_pdf_dataset():
+    try:
+        return load_pdf_fixture_dataset()
+    except PdfFixtureDatasetUnavailable as exc:
+        pytest.skip(str(exc))
+
+
 @pytest.fixture(scope="session")
 def pdf_dataset():
-    return datasets.load_dataset("datalab-to/pdfs", split="train")
+    return load_or_skip_pdf_dataset()
 
 
 @pytest.fixture(scope="function")

--- a/tests/test_dataset_fixture.py
+++ b/tests/test_dataset_fixture.py
@@ -1,0 +1,56 @@
+"""Tests for contributor-safe sample-document dataset loading."""
+
+from __future__ import annotations
+
+import pytest
+from datasets.exceptions import DatasetNotFoundError
+
+from tests import conftest as test_config
+from tests import utils
+
+
+def test_load_pdf_fixture_dataset_uses_the_existing_hub_source(monkeypatch) -> None:
+    sentinel = object()
+    calls: list[tuple[str, str]] = []
+
+    def load_dataset(dataset_id: str, *, split: str) -> object:
+        calls.append((dataset_id, split))
+        return sentinel
+
+    monkeypatch.setattr(utils.datasets, "load_dataset", load_dataset)
+
+    assert utils.load_pdf_fixture_dataset() is sentinel
+    assert calls == [("datalab-to/pdfs", "train")]
+
+
+def test_load_pdf_fixture_dataset_hides_hub_error_details(monkeypatch) -> None:
+    def load_dataset(dataset_id: str, *, split: str) -> object:
+        raise DatasetNotFoundError("private-hub-error-detail")
+
+    monkeypatch.setattr(utils.datasets, "load_dataset", load_dataset)
+
+    with pytest.raises(utils.PdfFixtureDatasetUnavailable) as exc_info:
+        utils.load_pdf_fixture_dataset()
+
+    assert str(exc_info.value) == (
+        "sample document dataset datalab-to/pdfs is unavailable"
+    )
+    assert "private-hub-error-detail" not in str(exc_info.value)
+
+
+def test_pdf_dataset_fixture_skips_when_the_hub_source_is_unavailable(
+    monkeypatch,
+) -> None:
+    def unavailable() -> object:
+        raise utils.PdfFixtureDatasetUnavailable(
+            "sample document dataset datalab-to/pdfs is unavailable"
+        )
+
+    monkeypatch.setattr(test_config, "load_pdf_fixture_dataset", unavailable)
+
+    with pytest.raises(pytest.skip.Exception) as exc_info:
+        test_config.load_or_skip_pdf_dataset()
+
+    assert str(exc_info.value) == (
+        "sample document dataset datalab-to/pdfs is unavailable"
+    )

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -2,17 +2,33 @@ from marker.providers.pdf import PdfProvider
 import tempfile
 
 import datasets
+from datasets.exceptions import DatasetNotFoundError
+
+
+class PdfFixtureDatasetUnavailable(RuntimeError):
+    """Raised when the gated sample-document dataset cannot be loaded."""
+
+
+def load_pdf_fixture_dataset():
+    """Load the existing sample dataset without reflecting Hub error details."""
+
+    try:
+        return datasets.load_dataset("datalab-to/pdfs", split="train")
+    except DatasetNotFoundError:
+        raise PdfFixtureDatasetUnavailable(
+            "sample document dataset datalab-to/pdfs is unavailable"
+        ) from None
 
 
 def setup_pdf_provider(
-    filename='adversarial.pdf',
+    filename="adversarial.pdf",
     config=None,
 ) -> PdfProvider:
-    dataset = datasets.load_dataset("datalab-to/pdfs", split="train")
-    idx = dataset['filename'].index(filename)
+    dataset = load_pdf_fixture_dataset()
+    idx = dataset["filename"].index(filename)
 
     temp_pdf = tempfile.NamedTemporaryFile(suffix=".pdf")
-    temp_pdf.write(dataset['pdf'][idx])
+    temp_pdf.write(dataset["pdf"][idx])
     temp_pdf.flush()
 
     provider = PdfProvider(temp_pdf.name, config)


### PR DESCRIPTION
## Summary

- Keep the existing `datalab-to/pdfs` Hub source and `train` split unchanged.
- Convert only `DatasetNotFoundError` into an explicit session-level skip.
- Preflight the multiprocessing override test before it creates worker processes.
- Add focused tests for the successful Hub path, fixed error boundary, and skip behavior.

## Scope

This is a narrow contributor-experience mitigation. It does not restore,
redistribute, or replace the gated sample-document corpus, and it intentionally
leaves #1084 open for a durable fixture source.

Related to #1084.

## Testing

- `uv run pytest tests/test_dataset_fixture.py -q` — 3 passed
- `uv run pytest tests/builders/test_overriding.py::test_overriding_mp -q -rs` — 1 skipped with the expected reason
- Provider/builder fixture checks — 8 skipped with the expected reason
- `uv run pytest -m "not integration" -q -rs` — 10 passed, 73 skipped, 1 environment failure
- The remaining image-provider failure requires `llama-server` and reproduces unchanged on `origin/master`
- Pre-commit Ruff lint and format hooks — passed
- Pyright on the new loader/fixture/tests — 0 errors