### PR TITLE
Batch durability fixes, and let the test suite run without dataset access

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,9 @@ marker /path/to/input/folder
 - `--workers` is the number of conversion workers to run simultaneously.  This is automatically set by default, but you can increase it to increase throughput, at the cost of more CPU usage.  All workers share a single inference server, which the parent process spawns.
 - The parent budgets total VLM concurrency automatically: it reads the server's capacity and splits it across workers (aggregate in-flight ≈ 1.5× capacity), so adding workers never over-queues the server.  Set `SURYA_INFERENCE_PARALLEL` yourself only to override.
 - With `--disable_ocr` no inference server is started at all, and the pool is sized purely by CPU cores.
-- `--skip_existing` skips input files that already have output in `--output_dir` (resume a run); `--max_files N` caps how many files are converted; `--disable_multiprocessing` runs everything in one process.
+- `--skip_existing` skips files that already have complete output *in the format you are converting to*.  Converting a folder to markdown and then rerunning with `--output_format json --skip_existing` converts the files again, rather than skipping them because a `.md` is sitting beside them.
+- `--max_files N` caps how many files are converted; `--disable_multiprocessing` runs everything in one process.
+- If any file fails, marker writes `conversion_failures.json` into the output directory, listing each failed path with its error, and logs how many failed and how many were skipped.  The file is a list you can feed back in to retry only what failed.  Chunked runs name it `conversion_failures_chunk_N.json` so they do not overwrite each other.
 
 ### Batch sizing cheat sheet (e.g. 1000 docs)
 
@@ -445,6 +447,7 @@ There are some settings that you may find useful if things aren't working the wa
 - Make sure to set `force_ocr` if you see garbled text - this will re-OCR the document.
 - `TORCH_DEVICE` - set this to force the small local models (ocr error detection) onto a given torch device.  The VLM runs in the inference server - control its placement with `SURYA_INFERENCE_BACKEND` / `VLLM_GPUS`.
 - If you're getting out of memory errors, decrease worker count.  You can also try splitting up long PDFs into multiple files.
+- A file that cannot be a PDF is now named as such before any parsing starts - an empty file, or a download that saved an error page under a `.pdf` name, reports that rather than a data format error from inside PDFium.  A password-protected PDF says it is encrypted; marker does not ask for a password, so supply a decrypted copy.
 
 ## Debugging
 

--- a/marker/output.py
+++ b/marker/output.py
@@ -1,5 +1,8 @@
+import io
 import json
 import os
+import uuid
+from typing import Optional
 
 from bs4 import BeautifulSoup, Tag
 from pydantic import BaseModel
@@ -47,12 +50,63 @@ def json_to_html(block: JSONBlockOutput | BlockOutput):
     return str(BeautifulSoup(_splice_json_html(block), "html.parser"))
 
 
-def output_exists(output_dir: str, fname_base: str):
-    exts = ["md", "html", "json"]
-    for ext in exts:
-        if os.path.exists(os.path.join(output_dir, f"{fname_base}.{ext}")):
-            return True
-    return False
+# The file extension `save_output` writes for each `--output_format`.
+OUTPUT_FORMAT_EXTENSIONS = {
+    "markdown": "md",
+    "html": "html",
+    "json": "json",
+    "chunks": "json",
+}
+
+
+def output_exists(
+    output_dir: str, fname_base: str, output_format: Optional[str] = None
+) -> bool:
+    """Whether a complete conversion is already on disk.
+
+    `output_format` matters because a markdown conversion says nothing about
+    whether the json one was ever run; without it, every known extension counts.
+    The metadata file is written last, so its absence means an earlier run was
+    interrupted partway through and left outputs that should not be reused.
+    """
+    if not os.path.exists(os.path.join(output_dir, f"{fname_base}_meta.json")):
+        return False
+
+    format_ext = OUTPUT_FORMAT_EXTENSIONS.get(output_format)
+    exts = (
+        [format_ext]
+        if format_ext
+        else list(dict.fromkeys(OUTPUT_FORMAT_EXTENSIONS.values()))
+    )
+    return any(
+        os.path.exists(os.path.join(output_dir, f"{fname_base}.{ext}")) for ext in exts
+    )
+
+
+def atomic_write_bytes(path: str, content: bytes) -> None:
+    """Write a file that is never observable in a half-written state.
+
+    An output truncated by an interrupted run is indistinguishable from a
+    finished one, which is exactly what `output_exists` would then skip over.
+    """
+    directory = os.path.dirname(path) or "."
+    os.makedirs(directory, exist_ok=True)
+    # Named rather than `mkstemp`ed, which would hand the finished file the
+    # 0600 permissions of a temporary one instead of the usual umask default.
+    tmp_path = os.path.join(
+        directory, f".{os.path.basename(path)}.{uuid.uuid4().hex}.tmp"
+    )
+    try:
+        with open(tmp_path, "wb") as f:
+            f.write(content)
+        os.replace(tmp_path, path)
+    finally:
+        if os.path.exists(tmp_path):
+            os.remove(tmp_path)
+
+
+def atomic_write_text(path: str, content: str) -> None:
+    atomic_write_bytes(path, content.encode(settings.OUTPUT_ENCODING, errors="replace"))
 
 
 def text_from_rendered(rendered: BaseModel):
@@ -78,25 +132,19 @@ def convert_if_not_rgb(image: Image.Image) -> Image.Image:
     return image
 
 
-def save_output(rendered: BaseModel, output_dir: str, fname_base: str):
+def save_output(rendered: BaseModel, output_dir: str, fname_base: str) -> None:
     text, ext, images = text_from_rendered(rendered)
-    text = text.encode(settings.OUTPUT_ENCODING, errors="replace").decode(
-        settings.OUTPUT_ENCODING
-    )
 
-    with open(
-        os.path.join(output_dir, f"{fname_base}.{ext}"),
-        "w+",
-        encoding=settings.OUTPUT_ENCODING,
-    ) as f:
-        f.write(text)
-    with open(
-        os.path.join(output_dir, f"{fname_base}_meta.json"),
-        "w+",
-        encoding=settings.OUTPUT_ENCODING,
-    ) as f:
-        f.write(json.dumps(rendered.metadata, indent=2))
+    atomic_write_text(os.path.join(output_dir, f"{fname_base}.{ext}"), text)
 
     for img_name, img in images.items():
         img = convert_if_not_rgb(img)  # RGBA images can't save as JPG
-        img.save(os.path.join(output_dir, img_name), settings.OUTPUT_IMAGE_FORMAT)
+        buffer = io.BytesIO()
+        img.save(buffer, settings.OUTPUT_IMAGE_FORMAT)
+        atomic_write_bytes(os.path.join(output_dir, img_name), buffer.getvalue())
+
+    # Written last, so its presence marks a conversion that reached disk whole.
+    atomic_write_text(
+        os.path.join(output_dir, f"{fname_base}_meta.json"),
+        json.dumps(rendered.metadata, indent=2),
+    )

--- a/marker/output.py
+++ b/marker/output.py
@@ -2,7 +2,7 @@ import io
 import json
 import os
 import uuid
-from typing import Optional
+from typing import Dict, List, Optional
 
 from bs4 import BeautifulSoup, Tag
 from pydantic import BaseModel
@@ -107,6 +107,17 @@ def atomic_write_bytes(path: str, content: bytes) -> None:
 
 def atomic_write_text(path: str, content: str) -> None:
     atomic_write_bytes(path, content.encode(settings.OUTPUT_ENCODING, errors="replace"))
+
+
+def write_failure_report(
+    output_dir: str,
+    failures: List[Dict[str, str]],
+    fname: str = "conversion_failures.json",
+) -> str:
+    """Record which inputs failed, so a batch can be re-run against the list."""
+    path = os.path.join(output_dir, fname)
+    atomic_write_text(path, json.dumps(failures, indent=2))
+    return path
 
 
 def text_from_rendered(rendered: BaseModel):

--- a/marker/providers/pdf.py
+++ b/marker/providers/pdf.py
@@ -15,6 +15,11 @@ from PIL import Image
 from pypdfium2 import PdfiumError, PdfDocument
 
 from marker.providers import BaseProvider, ProviderOutput, Char, ProviderPageLines
+from marker.providers.preflight import (
+    UnreadablePdfError,
+    preflight_pdf,
+    unreadable_pdf_message,
+)
 from marker.providers.text_cleanup import clean_extracted_text
 from marker.providers.utils import alphanum_ratio
 from marker.schema import BlockTypes
@@ -92,6 +97,8 @@ class PdfProvider(BaseProvider):
         super().__init__(filepath, config)
 
         self.filepath = filepath
+        preflight_pdf(filepath)
+
         self.raw_pdftext_pages: Dict[int, dict] = {}
 
         with self.get_doc() as doc:
@@ -118,7 +125,14 @@ class PdfProvider(BaseProvider):
     def get_doc(self):
         doc = None
         try:
-            doc = pdfium.PdfDocument(self.filepath)
+            try:
+                doc = pdfium.PdfDocument(self.filepath)
+            except PdfiumError as e:
+                # PDFium says the same thing about a damaged document and a
+                # password-protected one, and neither is worth a traceback.
+                raise UnreadablePdfError(
+                    unreadable_pdf_message(self.filepath, e)
+                ) from e
 
             # Must be called on the parent pdf, before retrieving pages to render correctly
             if self.flatten_pdf:

--- a/marker/providers/pdf.py
+++ b/marker/providers/pdf.py
@@ -15,6 +15,7 @@ from PIL import Image
 from pypdfium2 import PdfiumError, PdfDocument
 
 from marker.providers import BaseProvider, ProviderOutput, Char, ProviderPageLines
+from marker.providers.text_cleanup import clean_extracted_text
 from marker.providers.utils import alphanum_ratio
 from marker.schema import BlockTypes
 from marker.schema.polygon import PolygonBox
@@ -253,7 +254,9 @@ class PdfProvider(BaseProvider):
                         )
                         superscript = span.get("superscript", False)
                         subscript = span.get("subscript", False)
-                        text = self.normalize_spaces(fix_text(span["text"]))
+                        text = self.normalize_spaces(
+                            clean_extracted_text(fix_text(span["text"]))
+                        )
                         if superscript or subscript:
                             text = text.strip()
 

--- a/marker/providers/preflight.py
+++ b/marker/providers/preflight.py
@@ -1,0 +1,64 @@
+"""Checks a PDF must pass before PDFium is asked to parse it.
+
+PDFium answers "Data format error" for an empty file, a download that saved an
+error page under a .pdf name, and a genuinely damaged document alike, several
+seconds into a conversion and from deep inside a worker.  These checks are the
+ones that can be made from the bytes with certainty, so that a file marker
+cannot read is named as such at the start.
+
+They deliberately refuse nothing PDFium would accept.  There are no size, page
+count or resolution limits here: a document marker converts today must still
+convert.  A PDF encrypted with an empty user password is one of those -- it
+opens for everyone else, so it opens here, and nothing below looks for it.
+"""
+
+import os
+
+PDF_SIGNATURE = b"%PDF-"
+# PDFium reads a header that is not at byte zero, but stops looking after the
+# first kilobyte.  Verified against pypdfium2: offset 300 opens, offset 2000
+# does not.  Matching that window means preflight refuses only what PDFium
+# would refuse anyway.
+SIGNATURE_SEARCH_BYTES = 1024
+
+
+# What PDFium reports for a document it cannot decrypt, from pypdfium2's own
+# error table: FPDF_ERR_PASSWORD and FPDF_ERR_SECURITY.
+ENCRYPTION_ERRORS = ("incorrect password", "unsupported security scheme")
+
+
+class UnreadablePdfError(ValueError):
+    """Raised for a file that cannot be a PDF, before any parser sees it."""
+
+
+def preflight_pdf(filepath: str) -> None:
+    """Raise `UnreadablePdfError` if this file cannot be a PDF.
+
+    Passing says only that a parser should be given the file, not that the
+    document is intact -- that is PDFium's judgement to make.
+    """
+    if not os.path.isfile(filepath):
+        raise UnreadablePdfError(f"{filepath} is not a file that can be read.")
+
+    if os.path.getsize(filepath) == 0:
+        raise UnreadablePdfError(f"{filepath} is empty.")
+
+    with open(filepath, "rb") as f:
+        head = f.read(SIGNATURE_SEARCH_BYTES)
+
+    if PDF_SIGNATURE not in head:
+        raise UnreadablePdfError(
+            f"{filepath} is not a PDF: no %PDF- header in its first "
+            f"{SIGNATURE_SEARCH_BYTES} bytes."
+        )
+
+
+def unreadable_pdf_message(filepath: str, error: Exception) -> str:
+    """Say what PDFium's refusal to open a file means, in the caller's terms."""
+    reported = str(error).lower()
+    if any(signal in reported for signal in ENCRYPTION_ERRORS):
+        return (
+            f"{filepath} is encrypted and could not be opened.  Marker does not "
+            f"ask for a password; supply a decrypted copy instead."
+        )
+    return f"{filepath} could not be read as a PDF: {error}"

--- a/marker/providers/text_cleanup.py
+++ b/marker/providers/text_cleanup.py
@@ -1,0 +1,101 @@
+"""Characters a PDF hands over that belong to the layout rather than a word.
+
+PDFium reports what the font's `/ToUnicode` map claims, and `ftfy.fix_text`
+leaves all of this alone: it repairs mojibake, not a font telling the truth
+about a glyph nobody can render.
+"""
+
+# Adobe's Corporate Use Subarea, limited to the glyphs Adobe's own list names as
+# variants of a character that has a Unicode value.  A book set in oldstyle
+# figures otherwise reports its dates as unrenderable private-use codes.
+ADOBE_GLYPH_VARIANTS = {
+    0xF6D9: 0x00A9,  # copyrightserif
+    0xF6DB: 0x2122,  # trademarkserif
+    0xF724: 0x0024,  # dollaroldstyle
+    0xF730: 0x0030,  # zerooldstyle
+    0xF731: 0x0031,  # oneoldstyle
+    0xF732: 0x0032,  # twooldstyle
+    0xF733: 0x0033,  # threeoldstyle
+    0xF734: 0x0034,  # fouroldstyle
+    0xF735: 0x0035,  # fiveoldstyle
+    0xF736: 0x0036,  # sixoldstyle
+    0xF737: 0x0037,  # sevenoldstyle
+    0xF738: 0x0038,  # eightoldstyle
+    0xF739: 0x0039,  # nineoldstyle
+    0xF7A2: 0x00A2,  # centoldstyle
+    0xF8E9: 0x00A9,  # copyrightsans
+    0xF8EA: 0x2122,  # trademarksans
+}
+
+# Invisible characters that describe how a word may be broken, not what it says.
+# The zero-width joiners are deliberately absent: they carry meaning in Indic,
+# Arabic and Persian text and in emoji sequences, so dropping them would corrupt
+# real content.
+DISCARDABLE_FORMATTING = {
+    "­",  # soft hyphen
+    "﻿",  # byte order mark / zero width no-break space
+}
+
+
+def resolve_adobe_glyph_variants(text: str) -> str:
+    """Replace Adobe Corporate Use Subarea glyphs with the characters they name.
+
+    Private-use characters from anywhere else are left exactly as extracted.
+    A font's assignment means nothing outside that font, and a producer that
+    maps part of a subset to real characters and leaves the rest private is
+    stating its own limit -- resolving those would be inventing text.
+    """
+    if not text:
+        return text
+
+    return "".join(
+        chr(ADOBE_GLYPH_VARIANTS[ord(character)])
+        if ord(character) in ADOBE_GLYPH_VARIANTS
+        else character
+        for character in text
+    )
+
+
+def is_discardable_formatting(character: str) -> bool:
+    """True for a character that carries layout, never a word.
+
+    Besides the invisible formatting above, this covers the Unicode
+    *noncharacters* -- U+FDD0..U+FDEF and U+nFFFE/U+nFFFF in every plane.  They
+    are permanently reserved and never valid in interchange, and PDFium hands
+    them over where a PDF's font maps a hyphenation point to an unassigned slot.
+    Left in the text they corrupt the word around them -- `de<U+FFFE>picted` --
+    and hand a strict downstream consumer a document it must reject.
+    """
+    if character in DISCARDABLE_FORMATTING:
+        return True
+
+    code = ord(character)
+    if 0xFDD0 <= code <= 0xFDEF:
+        return True
+    return code & 0xFFFE == 0xFFFE
+
+
+def clean_extracted_text(text: str) -> str:
+    """Resolve what the font meant, and drop what belongs to the layout.
+
+    A discardable character immediately before a line break is a hyphenation
+    point, exactly as a trailing "-" is, and becomes one: dropping it outright
+    would leave a broken word with nothing to say it was broken, and marker
+    would rejoin it as two words.  Everywhere else it simply goes.
+    """
+    if not text:
+        return text
+
+    resolved = resolve_adobe_glyph_variants(text)
+    cleaned = []
+    for position, character in enumerate(resolved):
+        if not is_discardable_formatting(character):
+            cleaned.append(character)
+            continue
+
+        following = resolved[position + 1 : position + 2]
+        breaks_line = following in ("\n", "\r")
+        if breaks_line and cleaned[-1:] != ["-"]:
+            cleaned.append("-")
+
+    return "".join(cleaned)

--- a/marker/scripts/batch_outcomes.py
+++ b/marker/scripts/batch_outcomes.py
@@ -1,0 +1,65 @@
+"""What a batch conversion has to say about the files it was given.
+
+Kept apart from `convert.py` because that module configures threading and
+device environment variables at import time, and this needs neither.
+"""
+
+from typing import Dict, List, NamedTuple, Optional
+
+from marker.logger import get_logger
+from marker.output import write_failure_report
+
+logger = get_logger()
+
+
+class ConversionResult(NamedTuple):
+    """The outcome of one worker converting one input file."""
+
+    fpath: str
+    page_count: int = 0
+    skipped: bool = False
+    error: Optional[str] = None
+
+
+def failure_report_name(chunk_idx: int, num_chunks: int) -> str:
+    """Chunks of one run share an output directory, so they need distinct names."""
+    if num_chunks == 1:
+        return "conversion_failures.json"
+    return f"conversion_failures_chunk_{chunk_idx}.json"
+
+
+def failure_records(results: List[ConversionResult]) -> List[Dict[str, str]]:
+    return [
+        {"file": result.fpath, "error": result.error}
+        for result in results
+        if result.error
+    ]
+
+
+def report_outcomes(
+    results: List[ConversionResult],
+    output_dir: str,
+    chunk_idx: int = 0,
+    num_chunks: int = 1,
+) -> Optional[str]:
+    """Summarise a batch and leave its failures behind as a re-runnable list.
+
+    Without this, the only record of a failed file is a traceback somewhere in
+    the scrollback of a run that may have covered hundreds of documents.
+    Returns the path to the failure report, or None if nothing failed.
+    """
+    skipped = [result for result in results if result.skipped]
+    if skipped:
+        logger.info(f"Skipped {len(skipped)} files with existing output.")
+
+    failures = failure_records(results)
+    if not failures:
+        return None
+
+    path = write_failure_report(
+        output_dir, failures, fname=failure_report_name(chunk_idx, num_chunks)
+    )
+    logger.warning(
+        f"{len(failures)} of {len(results)} files failed to convert.  See {path}"
+    )
+    return path

--- a/marker/scripts/convert.py
+++ b/marker/scripts/convert.py
@@ -34,6 +34,7 @@ from marker.config.printer import CustomClickPrinter
 from marker.logger import configure_logging, get_logger
 from marker.models import create_model_dict
 from marker.output import output_exists, save_output
+from marker.scripts.batch_outcomes import ConversionResult, report_outcomes
 
 configure_logging()
 logger = get_logger()
@@ -72,7 +73,7 @@ def process_single_pdf(args):
     if cli_options.get("skip_existing") and output_exists(
         out_folder, base_name, cli_options.get("output_format")
     ):
-        return page_count
+        return ConversionResult(fpath, skipped=True)
 
     converter_cls = config_parser.get_converter_cls()
     config_dict = config_parser.generate_config_dict()
@@ -106,10 +107,11 @@ def process_single_pdf(args):
     except Exception as e:
         logger.error(f"Error converting {fpath}: {e}")
         traceback.print_exc()
+        return ConversionResult(fpath, error=f"{type(e).__name__}: {e}")
     finally:
         gc.collect()
 
-    return page_count
+    return ConversionResult(fpath, page_count=page_count)
 
 
 @click.command(cls=CustomClickPrinter)
@@ -236,12 +238,15 @@ def convert_cli(in_folder: str, **kwargs):
         maxtasksperchild=kwargs["max_tasks_per_worker"],
     ) as pool:
         pbar = tqdm(total=len(task_args), desc="Processing PDFs", unit="pdf")
-        for page_count in pool.imap_unordered(process_single_pdf, task_args):
+        results = []
+        for result in pool.imap_unordered(process_single_pdf, task_args):
             pbar.update(1)
-            total_pages += page_count
+            total_pages += result.page_count
+            results.append(result)
         pbar.close()
 
     total_time = time.time() - start_time
     print(
         f"Inferenced {total_pages} pages in {total_time:.2f} seconds, for a throughput of {total_pages / total_time:.2f} pages/sec for chunk {chunk_idx + 1}/{kwargs['num_chunks']}"
     )
+    report_outcomes(results, kwargs["output_dir"], chunk_idx, kwargs["num_chunks"])

--- a/marker/scripts/convert.py
+++ b/marker/scripts/convert.py
@@ -69,7 +69,9 @@ def process_single_pdf(args):
 
     out_folder = config_parser.get_output_folder(fpath)
     base_name = config_parser.get_base_filename(fpath)
-    if cli_options.get("skip_existing") and output_exists(out_folder, base_name):
+    if cli_options.get("skip_existing") and output_exists(
+        out_folder, base_name, cli_options.get("output_format")
+    ):
         return page_count
 
     converter_cls = config_parser.get_converter_cls()

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,85 @@
+# Running the tests
+
+```bash
+uv run pytest -m "not integration" -q
+```
+
+`integration`-marked tests run the VLM over real pages and are slow; they are
+excluded above.  The `cpu` marker selects the tests that need no GPU or
+inference server (`-m cpu`).
+
+## Sample documents
+
+Most tests convert a sample document named by a `filename` marker:
+
+```python
+@pytest.mark.filename("thinkpython.pdf")
+def test_something(pdf_document): ...
+```
+
+Tests without the marker get `adversarial.pdf`.
+
+Those documents come from the [`datalab-to/pdfs`][dataset] dataset on the
+HuggingFace Hub, which is **gated** — the Hub answers HTTP 401 without an
+access token.  When a document cannot be found, the test **skips with a reason
+naming the file and both sources** rather than erroring.  A full run then looks
+like:
+
+```
+65 passed, 73 skipped, 3 deselected
+```
+
+`tests/dataset.py` resolves each document from two sources, in order.
+
+### 1. A local directory
+
+Drop documents into `tests/data/pdfs/`, named exactly as the tests request
+them (`adversarial.pdf`, `gatsby.docx`, `single_sheet.xlsx`, ...).  Point
+somewhere else with:
+
+```bash
+MARKER_TEST_PDF_DIR=/path/to/samples uv run pytest -m "not integration" -q
+```
+
+A local file wins over the Hub, so a fully populated directory runs the suite
+with no Hub access at all.
+
+Use the **real** documents: the tests assert on their actual content (for
+example `"# Subspace Adversarial Training"` from `adversarial.pdf`, and a
+12-page length).  A stand-in document loads fine but fails those assertions.
+
+Documents the suite currently asks for:
+
+| Type | Documents |
+| --- | --- |
+| PDF | `A17_FlightPlan.pdf`, `adversarial.pdf`, `adversarial_rot.pdf`, `arxiv_test.pdf`, `bio_pdf.pdf`, `form_1040.pdf`, `handwritten.pdf`, `hindi_judgement.pdf`, `multicol-blocks.pdf`, `population_stats.pdf`, `pres.pdf`, `table_ex.pdf`, `table_ex2.pdf`, `thinkpython.pdf`, `water_damage.pdf` |
+| Other | `china.html`, `gatsby.docx`, `lambda.pptx`, `manual.epub`, `single_sheet.xlsx` |
+
+Regenerate that list with:
+
+```bash
+grep -rho 'pytest.mark.filename("[^"]*")' tests/ | sed 's/.*("//;s/")//' | sort -u
+```
+
+### 2. The HuggingFace Hub
+
+Request access at <https://huggingface.co/datasets/datalab-to/pdfs>, then
+authenticate once:
+
+```bash
+uv run huggingface-cli login
+```
+
+Or set a token in the environment:
+
+```bash
+export HF_TOKEN=hf_...
+```
+
+Verify access with:
+
+```bash
+uv run python -c "import datasets; print(datasets.load_dataset('datalab-to/pdfs', split='train'))"
+```
+
+[dataset]: https://huggingface.co/datasets/datalab-to/pdfs

--- a/tests/builders/test_overriding.py
+++ b/tests/builders/test_overriding.py
@@ -8,7 +8,7 @@ from marker.schema.blocks import SectionHeader
 from marker.schema.document import Document
 from marker.schema.registry import register_block_class
 from marker.schema.text import Line
-from tests.utils import setup_pdf_provider
+from tests.utils import require_documents, setup_pdf_provider
 
 
 class NewSectionHeader(SectionHeader):
@@ -43,6 +43,8 @@ def test_overriding_mp():
     }
 
     pdf_list = ["adversarial.pdf", "adversarial_rot.pdf"]
+    # Check up front: a skip raised inside a worker comes back as a failure.
+    require_documents(*pdf_list)
 
     with mp.Pool(processes=2) as pool:
         results = pool.starmap(get_lines, [(pdf, config) for pdf in pdf_list])

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,6 @@ from typing import Dict, Type
 
 from PIL import Image, ImageDraw
 
-import datasets
 import pytest
 
 from marker.builders.document import DocumentBuilder
@@ -22,6 +21,12 @@ from marker.renderers.markdown import MarkdownRenderer
 from marker.renderers.json import JSONRenderer
 from marker.schema.registry import register_block_class
 from marker.util import classes_to_strings, strings_to_classes
+from tests.dataset import (
+    DEFAULT_DOCUMENT,
+    DocumentUnavailable,
+    hf_dataset,
+    load_document,
+)
 
 
 @pytest.fixture(scope="session")
@@ -65,19 +70,32 @@ def config(request):
 
 @pytest.fixture(scope="session")
 def pdf_dataset():
-    return datasets.load_dataset("datalab-to/pdfs", split="train")
+    """The raw sample-document dataset from the HuggingFace Hub.
+
+    Skips, rather than erroring, when the gated dataset is unreachable. Prefer
+    `temp_doc` for a single document -- it also accepts documents from the
+    local directory, so it does not need Hub access at all.
+    """
+    dataset, reason = hf_dataset()
+    if dataset is None:
+        pytest.skip(reason)
+    return dataset
 
 
 @pytest.fixture(scope="function")
-def temp_doc(request, pdf_dataset):
+def temp_doc(request):
+    """A sample document, named by the `filename` marker, on disk."""
     filename_mark = request.node.get_closest_marker("filename")
-    filename = filename_mark.args[0] if filename_mark else "adversarial.pdf"
+    filename = filename_mark.args[0] if filename_mark else DEFAULT_DOCUMENT
 
-    idx = pdf_dataset["filename"].index(filename)
+    try:
+        content = load_document(filename)
+    except DocumentUnavailable as exc:
+        pytest.skip(str(exc))
+
     suffix = filename.split(".")[-1]
-
     temp_pdf = tempfile.NamedTemporaryFile(suffix=f".{suffix}")
-    temp_pdf.write(pdf_dataset["pdf"][idx])
+    temp_pdf.write(content)
     temp_pdf.flush()
     yield temp_pdf
 

--- a/tests/data/pdfs/README.md
+++ b/tests/data/pdfs/README.md
@@ -1,0 +1,8 @@
+# Local sample documents
+
+Drop sample documents here, named exactly as the tests request them
+(`adversarial.pdf`, `gatsby.docx`, ...), to run the suite without access to the
+gated `datalab-to/pdfs` dataset.  Files here take precedence over the Hub.
+
+See [../../README.md](../../README.md) for the list of documents the suite asks
+for and how to obtain them.  Mind the licensing of anything you commit here.

--- a/tests/dataset.py
+++ b/tests/dataset.py
@@ -1,0 +1,160 @@
+"""Locating the sample documents that the test suite converts.
+
+Sample documents live in the ``datalab-to/pdfs`` dataset on the HuggingFace
+Hub.  That dataset is gated: without an access token the Hub answers HTTP 401,
+and every test that needs a sample document becomes unrunnable.  Resolving
+documents through this module means a missing corpus turns into a skip with an
+actionable reason instead of an error out of fixture setup.
+
+Sources are consulted in order:
+
+1. A local directory of sample documents, named exactly as the tests request
+   them (``adversarial.pdf``, ``gatsby.docx``, ...).  It defaults to
+   ``tests/data/pdfs`` and is overridable with ``MARKER_TEST_PDF_DIR``.
+2. The ``datalab-to/pdfs`` dataset on the HuggingFace Hub.
+
+See ``tests/README.md`` for how to make either source available.
+"""
+
+from __future__ import annotations
+
+import os
+from functools import lru_cache
+from pathlib import Path
+from typing import Optional, Tuple
+
+DATASET_NAME = "datalab-to/pdfs"
+DATASET_SPLIT = "train"
+
+#: Column holding the raw document bytes.  Named "pdf" upstream, but it also
+#: carries the .docx/.epub/.html/.pptx/.xlsx samples.
+DATASET_CONTENT_COLUMN = "pdf"
+DATASET_FILENAME_COLUMN = "filename"
+
+#: Document used by tests that do not carry a ``filename`` marker.
+DEFAULT_DOCUMENT = "adversarial.pdf"
+
+LOCAL_DIR_ENV_VAR = "MARKER_TEST_PDF_DIR"
+DEFAULT_LOCAL_DIR = Path(__file__).parent / "data" / "pdfs"
+
+SETUP_HINT = (
+    f"Grant access with `huggingface-cli login` after requesting the dataset at "
+    f"https://huggingface.co/datasets/{DATASET_NAME}, or drop the file into the "
+    f"local directory (override it with ${LOCAL_DIR_ENV_VAR}). See tests/README.md."
+)
+
+
+class DocumentUnavailable(Exception):
+    """A requested sample document was not found in any source."""
+
+
+def local_dir() -> Path:
+    """Directory searched for sample documents before the Hub is consulted."""
+    override = os.environ.get(LOCAL_DIR_ENV_VAR)
+    return Path(override).expanduser() if override else DEFAULT_LOCAL_DIR
+
+
+def _local_path(filename: str) -> Optional[Path]:
+    """Resolve ``filename`` inside the local directory, or None if it is not a
+    plain file name (guards against a marker escaping the directory)."""
+    if not filename or Path(filename).name != filename:
+        return None
+    return local_dir() / filename
+
+
+def _from_local(filename: str) -> Tuple[Optional[bytes], str]:
+    """Return ``(content, reason)``; ``content`` is None when unavailable."""
+    path = _local_path(filename)
+    if path is None:
+        return None, f"{filename!r} is not a plain file name"
+    if not path.is_file():
+        return None, f"no such file: {path}"
+    try:
+        return path.read_bytes(), ""
+    except OSError as exc:
+        return None, f"could not read {path}: {exc}"
+
+
+@lru_cache(maxsize=1)
+def _load_hf_dataset() -> Tuple[Optional[object], str]:
+    """Load the Hub dataset once per process.
+
+    Returns ``(dataset, reason)``.  Any failure -- gated dataset, no token, no
+    network -- is reported as a reason rather than raised, so that a caller can
+    fall back or skip.
+    """
+    try:
+        import datasets
+    except ImportError as exc:  # pragma: no cover - datasets is a test dep
+        return None, f"the `datasets` package is unavailable: {exc}"
+
+    try:
+        return datasets.load_dataset(DATASET_NAME, split=DATASET_SPLIT), ""
+    except Exception as exc:
+        return None, f"{type(exc).__name__}: {exc}"
+
+
+def _from_hf_dataset(filename: str) -> Tuple[Optional[bytes], str]:
+    """Return ``(content, reason)``; ``content`` is None when unavailable."""
+    dataset, reason = _load_hf_dataset()
+    if dataset is None:
+        return None, reason
+
+    try:
+        idx = dataset[DATASET_FILENAME_COLUMN].index(filename)
+    except ValueError:
+        return None, f"{DATASET_NAME} has no entry named {filename!r}"
+    except Exception as exc:
+        return None, f"could not read {DATASET_NAME}: {type(exc).__name__}: {exc}"
+
+    return dataset[DATASET_CONTENT_COLUMN][idx], ""
+
+
+def unavailable_reason(filename: str) -> Optional[str]:
+    """Explain why ``filename`` cannot be loaded, or None if it can.
+
+    Consulting both sources is what makes the message actionable, so this does
+    the same work as :func:`load_document` and is cheap to call afterwards --
+    the Hub lookup is cached per process.
+    """
+    _, local_reason = _from_local(filename)
+    if not local_reason:
+        return None
+
+    _, hub_reason = _from_hf_dataset(filename)
+    if not hub_reason:
+        return None
+
+    return (
+        f"sample document {filename!r} is unavailable "
+        f"(local: {local_reason}; hub: {hub_reason}). {SETUP_HINT}"
+    )
+
+
+def load_document(filename: str) -> bytes:
+    """Return the bytes of sample document ``filename``.
+
+    Raises :class:`DocumentUnavailable`, naming both sources, if neither has it.
+    """
+    content, local_reason = _from_local(filename)
+    if content is not None:
+        return content
+
+    content, hub_reason = _from_hf_dataset(filename)
+    if content is not None:
+        return content
+
+    raise DocumentUnavailable(
+        f"sample document {filename!r} is unavailable "
+        f"(local: {local_reason}; hub: {hub_reason}). {SETUP_HINT}"
+    )
+
+
+def hf_dataset() -> Tuple[Optional[object], str]:
+    """Return ``(dataset, reason)`` for the raw Hub dataset.
+
+    ``dataset`` is None when the Hub could not be reached; ``reason`` then says
+    why.  Exposed for tests that need the corpus itself rather than one
+    document.
+    """
+    return _load_hf_dataset()

--- a/tests/test_batch_outcomes.py
+++ b/tests/test_batch_outcomes.py
@@ -1,0 +1,49 @@
+import json
+import os
+
+from marker.scripts.batch_outcomes import (
+    ConversionResult,
+    failure_report_name,
+    report_outcomes,
+)
+
+
+def test_a_clean_batch_writes_no_report(tmp_path):
+    results = [
+        ConversionResult("/in/a.pdf", page_count=12),
+        ConversionResult("/in/b.pdf", skipped=True),
+    ]
+
+    assert report_outcomes(results, str(tmp_path)) is None
+    assert os.listdir(tmp_path) == []
+
+
+def test_failures_are_recorded_with_their_file(tmp_path):
+    results = [
+        ConversionResult("/in/a.pdf", page_count=12),
+        ConversionResult("/in/b.pdf", error="PdfiumError: Incorrect password"),
+        ConversionResult("/in/c.pdf", error="ValueError: no pages"),
+    ]
+
+    path = report_outcomes(results, str(tmp_path))
+
+    assert json.loads(open(path).read()) == [
+        {"file": "/in/b.pdf", "error": "PdfiumError: Incorrect password"},
+        {"file": "/in/c.pdf", "error": "ValueError: no pages"},
+    ]
+
+
+def test_report_is_written_into_a_missing_output_dir(tmp_path):
+    output_dir = tmp_path / "not_yet_created"
+
+    path = report_outcomes(
+        [ConversionResult("/in/a.pdf", error="boom")], str(output_dir)
+    )
+
+    assert os.path.dirname(path) == str(output_dir)
+
+
+def test_chunks_do_not_overwrite_each_others_reports():
+    assert failure_report_name(0, 1) == "conversion_failures.json"
+    assert failure_report_name(0, 4) == "conversion_failures_chunk_0.json"
+    assert failure_report_name(3, 4) == "conversion_failures_chunk_3.json"

--- a/tests/test_dataset_resolution.py
+++ b/tests/test_dataset_resolution.py
@@ -1,0 +1,150 @@
+"""Tests for locating sample documents (see `tests/dataset.py`).
+
+These exercise the resolution logic itself, so they must keep passing whether
+or not the gated HuggingFace dataset happens to be reachable.
+"""
+
+import pytest
+
+from tests import dataset
+from tests.dataset import (
+    DocumentUnavailable,
+    load_document,
+    local_dir,
+    unavailable_reason,
+)
+
+# A name no real corpus will ever contain, so the "missing" assertions below
+# hold regardless of whether the Hub is reachable.
+MISSING_DOCUMENT = "no-such-sample-document-4f3a1b.pdf"
+
+
+@pytest.fixture
+def sample_dir(tmp_path, monkeypatch):
+    """Point the resolver at a directory this test controls."""
+    monkeypatch.setenv(dataset.LOCAL_DIR_ENV_VAR, str(tmp_path))
+    return tmp_path
+
+
+@pytest.mark.cpu
+def test_local_dir_follows_env_var(sample_dir):
+    assert local_dir() == sample_dir
+
+
+@pytest.mark.cpu
+def test_local_dir_defaults_under_tests_data(monkeypatch):
+    monkeypatch.delenv(dataset.LOCAL_DIR_ENV_VAR, raising=False)
+    assert local_dir() == dataset.DEFAULT_LOCAL_DIR
+    assert local_dir().name == "pdfs"
+
+
+@pytest.mark.cpu
+def test_loads_document_from_local_dir(sample_dir):
+    (sample_dir / "adversarial.pdf").write_bytes(b"%PDF-1.7 local copy")
+
+    assert load_document("adversarial.pdf") == b"%PDF-1.7 local copy"
+
+
+@pytest.mark.cpu
+def test_local_dir_takes_precedence_over_the_hub(sample_dir, monkeypatch):
+    """A local file wins, so the suite runs without any Hub access at all."""
+    (sample_dir / "thinkpython.pdf").write_bytes(b"%PDF-1.7 local wins")
+
+    def fail_if_called():  # pragma: no cover - asserted not to run
+        raise AssertionError("the Hub must not be consulted for a local file")
+
+    monkeypatch.setattr(dataset, "_load_hf_dataset", fail_if_called)
+
+    assert load_document("thinkpython.pdf") == b"%PDF-1.7 local wins"
+
+
+@pytest.mark.cpu
+def test_non_pdf_samples_load_by_name(sample_dir):
+    """The corpus also carries .docx/.epub/.html/.pptx/.xlsx samples."""
+    for name in ("gatsby.docx", "manual.epub", "china.html", "single_sheet.xlsx"):
+        (sample_dir / name).write_bytes(f"contents of {name}".encode())
+
+    for name in ("gatsby.docx", "manual.epub", "china.html", "single_sheet.xlsx"):
+        assert load_document(name) == f"contents of {name}".encode()
+
+
+@pytest.mark.cpu
+def test_missing_document_raises_with_both_sources_named(sample_dir):
+    with pytest.raises(DocumentUnavailable) as excinfo:
+        load_document(MISSING_DOCUMENT)
+
+    message = str(excinfo.value)
+    assert MISSING_DOCUMENT in message
+    assert "local:" in message and "hub:" in message
+    assert dataset.LOCAL_DIR_ENV_VAR in message
+
+
+@pytest.mark.cpu
+def test_unavailable_reason_is_none_when_present(sample_dir):
+    (sample_dir / "pres.pdf").write_bytes(b"%PDF-1.7")
+
+    assert unavailable_reason("pres.pdf") is None
+    assert unavailable_reason(MISSING_DOCUMENT) is not None
+
+
+@pytest.mark.cpu
+@pytest.mark.parametrize("filename", ["../secrets.pdf", "nested/doc.pdf", ""])
+def test_rejects_names_that_escape_the_local_dir(sample_dir, filename):
+    """Marker-supplied names are resolved inside the directory, never above it."""
+    with pytest.raises(DocumentUnavailable):
+        load_document(filename)
+
+
+@pytest.fixture
+def local_adversarial_pdf(sample_dir):
+    """Stage a local document *before* `temp_doc` resolves it."""
+    (sample_dir / "adversarial.pdf").write_bytes(b"%PDF-1.7 via fixture")
+    return sample_dir
+
+
+@pytest.mark.cpu
+@pytest.mark.filename("adversarial.pdf")
+def test_temp_doc_serves_a_local_document(local_adversarial_pdf, temp_doc):
+    """The `temp_doc` fixture reads the local directory, not just the Hub."""
+    assert temp_doc.name.endswith(".pdf")
+    with open(temp_doc.name, "rb") as f:
+        assert f.read() == b"%PDF-1.7 via fixture"
+
+
+@pytest.mark.cpu
+def test_hub_failure_is_reported_not_raised(sample_dir, monkeypatch):
+    """A gated or unreachable Hub must not raise out of fixture setup."""
+    monkeypatch.setattr(
+        dataset,
+        "_load_hf_dataset",
+        lambda: (None, "DatasetNotFoundError: cannot be accessed"),
+    )
+
+    hub_dataset, reason = dataset.hf_dataset()
+
+    assert hub_dataset is None
+    assert "cannot be accessed" in reason
+
+
+@pytest.mark.cpu
+def test_falls_back_to_the_hub_when_the_local_dir_lacks_it(sample_dir, monkeypatch):
+    """The Hub still serves documents, keyed the way the upstream corpus is."""
+    stub = {
+        dataset.DATASET_FILENAME_COLUMN: ["other.pdf", "form_1040.pdf"],
+        dataset.DATASET_CONTENT_COLUMN: [b"other", b"%PDF-1.7 from the hub"],
+    }
+    monkeypatch.setattr(dataset, "_load_hf_dataset", lambda: (stub, ""))
+
+    assert load_document("form_1040.pdf") == b"%PDF-1.7 from the hub"
+
+
+@pytest.mark.cpu
+def test_document_absent_from_the_hub_names_the_dataset(sample_dir, monkeypatch):
+    stub = {
+        dataset.DATASET_FILENAME_COLUMN: ["other.pdf"],
+        dataset.DATASET_CONTENT_COLUMN: [b"other"],
+    }
+    monkeypatch.setattr(dataset, "_load_hf_dataset", lambda: (stub, ""))
+
+    with pytest.raises(DocumentUnavailable, match=dataset.DATASET_NAME):
+        load_document(MISSING_DOCUMENT)

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -1,0 +1,90 @@
+import json
+import os
+
+import pytest
+from PIL import Image
+
+from marker.output import atomic_write_text, output_exists, save_output
+from marker.renderers.markdown import MarkdownOutput
+
+
+def markdown_output(images=None):
+    return MarkdownOutput(
+        markdown="# Title\n\nBody text.\n",
+        images=images or {},
+        metadata={"table_of_contents": []},
+    )
+
+
+def test_save_output_writes_every_part(tmp_path):
+    images = {"_page_0_Figure_1.jpeg": Image.new("RGB", (4, 4), "white")}
+    save_output(markdown_output(images), str(tmp_path), "doc")
+
+    assert (tmp_path / "doc.md").read_text().startswith("# Title")
+    assert json.loads((tmp_path / "doc_meta.json").read_text()) == {
+        "table_of_contents": []
+    }
+    assert (tmp_path / "_page_0_Figure_1.jpeg").exists()
+
+
+def test_output_exists_is_format_aware(tmp_path):
+    save_output(markdown_output(), str(tmp_path), "doc")
+
+    assert output_exists(str(tmp_path), "doc", "markdown")
+    # A markdown conversion says nothing about whether the json one was run.
+    assert not output_exists(str(tmp_path), "doc", "json")
+    assert not output_exists(str(tmp_path), "doc", "chunks")
+    assert not output_exists(str(tmp_path), "doc", "html")
+
+
+def test_output_exists_without_a_format_accepts_any(tmp_path):
+    save_output(markdown_output(), str(tmp_path), "doc")
+
+    assert output_exists(str(tmp_path), "doc")
+    assert not output_exists(str(tmp_path), "other")
+
+
+def test_output_exists_rejects_an_interrupted_conversion(tmp_path):
+    # A run killed after the markdown was written but before the images were.
+    with pytest.raises(AttributeError):
+        save_output(
+            markdown_output({"broken.jpeg": "not an image"}), str(tmp_path), "doc"
+        )
+
+    assert (tmp_path / "doc.md").exists()
+    assert not output_exists(str(tmp_path), "doc", "markdown")
+
+
+def test_atomic_write_text_never_leaves_a_partial_file(tmp_path, monkeypatch):
+    target = tmp_path / "doc.md"
+
+    def failing_replace(src, dst):
+        raise OSError("interrupted")
+
+    monkeypatch.setattr(os, "replace", failing_replace)
+    with pytest.raises(OSError):
+        atomic_write_text(str(target), "half a document")
+
+    assert not target.exists()
+    assert os.listdir(tmp_path) == []
+
+
+def test_atomic_write_text_replaces_an_existing_file(tmp_path):
+    target = tmp_path / "doc.md"
+    target.write_text("stale content that is much longer than the new content")
+
+    atomic_write_text(str(target), "fresh")
+
+    assert target.read_text() == "fresh"
+    assert os.listdir(tmp_path) == ["doc.md"]
+
+
+def test_atomic_write_keeps_the_usual_file_permissions(tmp_path):
+    reference = tmp_path / "reference.md"
+    with open(reference, "w") as f:
+        f.write("written the ordinary way")
+    target = tmp_path / "doc.md"
+
+    atomic_write_text(str(target), "written atomically")
+
+    assert oct(target.stat().st_mode) == oct(reference.stat().st_mode)

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -4,7 +4,12 @@ import os
 import pytest
 from PIL import Image
 
-from marker.output import atomic_write_text, output_exists, save_output
+from marker.output import (
+    atomic_write_text,
+    output_exists,
+    save_output,
+    write_failure_report,
+)
 from marker.renderers.markdown import MarkdownOutput
 
 
@@ -77,6 +82,28 @@ def test_atomic_write_text_replaces_an_existing_file(tmp_path):
 
     assert target.read_text() == "fresh"
     assert os.listdir(tmp_path) == ["doc.md"]
+
+
+def test_write_failure_report(tmp_path):
+    failures = [
+        {"file": "/in/a.pdf", "error": "PdfiumError: Incorrect password"},
+        {"file": "/in/b.pdf", "error": "ValueError: no pages"},
+    ]
+
+    path = write_failure_report(str(tmp_path), failures)
+
+    assert json.loads(open(path).read()) == failures
+    assert os.path.basename(path) == "conversion_failures.json"
+
+
+def test_write_failure_report_names_the_chunk(tmp_path):
+    path = write_failure_report(
+        str(tmp_path),
+        [{"file": "/in/a.pdf", "error": "boom"}],
+        fname="conversion_failures_chunk_2.json",
+    )
+
+    assert os.path.basename(path) == "conversion_failures_chunk_2.json"
 
 
 def test_atomic_write_keeps_the_usual_file_permissions(tmp_path):

--- a/tests/test_preflight.py
+++ b/tests/test_preflight.py
@@ -1,0 +1,111 @@
+import pypdfium2 as pdfium
+import pytest
+
+from marker.providers.preflight import (
+    UnreadablePdfError,
+    preflight_pdf,
+    unreadable_pdf_message,
+)
+
+
+@pytest.fixture
+def minimal_pdf(tmp_path):
+    """The smallest PDF PDFium will open, written by PDFium itself."""
+    path = tmp_path / "minimal.pdf"
+    doc = pdfium.PdfDocument.new()
+    doc.new_page(200, 200)
+    doc.save(str(path))
+    doc.close()
+    return path
+
+
+def test_a_real_pdf_passes(minimal_pdf):
+    assert preflight_pdf(str(minimal_pdf)) is None
+
+
+def test_a_header_offset_into_the_file_passes(minimal_pdf, tmp_path):
+    # PDFium reads a header that is not at byte zero, so refusing one here
+    # would refuse a document marker can convert today.
+    path = tmp_path / "offset.pdf"
+    path.write_bytes(b"\x00" * 300 + minimal_pdf.read_bytes())
+
+    assert preflight_pdf(str(path)) is None
+
+
+def test_a_header_beyond_the_search_window_is_refused(minimal_pdf, tmp_path):
+    # PDFium refuses this one too, verified against pypdfium2.
+    path = tmp_path / "far.pdf"
+    path.write_bytes(b"\x00" * 2000 + minimal_pdf.read_bytes())
+
+    with pytest.raises(UnreadablePdfError, match="not a PDF"):
+        preflight_pdf(str(path))
+
+
+def test_a_missing_file_is_named(tmp_path):
+    path = tmp_path / "absent.pdf"
+
+    with pytest.raises(UnreadablePdfError, match=str(path)):
+        preflight_pdf(str(path))
+
+
+def test_a_directory_is_not_a_document(tmp_path):
+    with pytest.raises(UnreadablePdfError):
+        preflight_pdf(str(tmp_path))
+
+
+def test_an_empty_file_says_so(tmp_path):
+    path = tmp_path / "empty.pdf"
+    path.touch()
+
+    with pytest.raises(UnreadablePdfError, match="empty"):
+        preflight_pdf(str(path))
+
+
+def test_a_file_that_is_not_a_pdf_says_so(tmp_path):
+    # A download that returned an error page and got saved with a .pdf name.
+    path = tmp_path / "notapdf.pdf"
+    path.write_text("<html><body><h1>404 Not Found</h1></body></html>")
+
+    with pytest.raises(UnreadablePdfError, match="not a PDF"):
+        preflight_pdf(str(path))
+
+
+def test_preflight_does_not_validate_the_document(tmp_path):
+    # Preflight refuses what cannot be a PDF; deciding whether a real PDF is
+    # intact is PDFium's job, and this file gets to reach it.
+    path = tmp_path / "truncated.pdf"
+    path.write_bytes(b"%PDF-1.4\n1 0 obj\n<< /Type /Catalog >>\ngarbage")
+
+    assert preflight_pdf(str(path)) is None
+
+
+def test_an_encryption_failure_is_reported_as_one():
+    # Both messages come from pypdfium2's own error table, for
+    # FPDF_ERR_PASSWORD and FPDF_ERR_SECURITY.
+    for reported in [
+        "Failed to load document (PDFium: Incorrect password error).",
+        "Failed to load document (PDFium: Unsupported security scheme error).",
+    ]:
+        message = unreadable_pdf_message("/in/secret.pdf", RuntimeError(reported))
+
+        assert "/in/secret.pdf" in message
+        assert "encrypted" in message
+        assert "password" in message
+
+
+def test_any_other_failure_keeps_what_pdfium_said():
+    message = unreadable_pdf_message(
+        "/in/broken.pdf",
+        RuntimeError("Failed to load document (PDFium: Data format error)."),
+    )
+
+    assert "/in/broken.pdf" in message
+    assert "Data format error" in message
+
+
+def test_the_error_is_catchable_as_a_value_error(tmp_path):
+    path = tmp_path / "empty.pdf"
+    path.touch()
+
+    with pytest.raises(ValueError):
+        preflight_pdf(str(path))

--- a/tests/test_text_cleanup.py
+++ b/tests/test_text_cleanup.py
@@ -1,0 +1,120 @@
+"""Characters PDFium hands over that are not part of any word.
+
+Written with explicit escapes throughout: every character under test is either
+invisible or a private-use glyph, and a literal would be unreadable here and
+easy to mangle in a later edit.
+"""
+
+from marker.providers.text_cleanup import (
+    clean_extracted_text,
+    is_discardable_formatting,
+    resolve_adobe_glyph_variants,
+)
+
+OLDSTYLE_2019 = ""
+
+
+def test_oldstyle_figures_become_digits():
+    # A PDF setting "2019" in oldstyle figures hands over these glyph codes.
+    assert resolve_adobe_glyph_variants(OLDSTYLE_2019) == "2019"
+
+
+def test_symbol_variants_become_their_characters():
+    assert resolve_adobe_glyph_variants(" ") == "© ©"  # serif, sans
+    assert resolve_adobe_glyph_variants(" ") == "™ ™"
+    assert resolve_adobe_glyph_variants("") == "$¢"
+
+
+def test_private_use_outside_the_subarea_is_left_alone():
+    # A font's own assignment means nothing outside that font, so resolving it
+    # would be inventing text.  U+F8FF is Apple's logo, not a copyright sign.
+    for character in ["", "", "\U000f0000", "\U00100000"]:
+        assert resolve_adobe_glyph_variants(character) == character
+
+
+def test_resolving_leaves_ordinary_text_untouched():
+    assert resolve_adobe_glyph_variants("Ordinary text, 2019. ©") == (
+        "Ordinary text, 2019. ©"
+    )
+    assert resolve_adobe_glyph_variants("") == ""
+
+
+def test_noncharacters_are_discardable():
+    for character in ["￾", "￿", "﷐", "﷯"]:
+        assert is_discardable_formatting(character)
+    # Reserved in every plane, not only the BMP.
+    for character in ["\U0001fffe", "\U0010ffff"]:
+        assert is_discardable_formatting(character)
+
+
+def test_invisible_formatting_is_discardable():
+    assert is_discardable_formatting("­")  # soft hyphen
+    assert is_discardable_formatting("﻿")  # byte order mark / ZWNBSP
+
+
+def test_zero_width_joiners_are_kept():
+    # Marker reads Indic, Arabic and emoji text, where these carry meaning.
+    for character in ["‌", "‍"]:
+        assert not is_discardable_formatting(character)
+
+
+def test_ordinary_characters_are_not_discardable():
+    for character in ["a", " ", "\n", "-", "©", "�", "क"]:
+        assert not is_discardable_formatting(character)
+
+
+def test_a_soft_hyphen_inside_a_word_is_dropped():
+    assert clean_extracted_text("hyphen­ation") == "hyphenation"
+
+
+def test_a_noncharacter_inside_a_word_is_dropped():
+    # PDFium hands these over where a font maps a hyphenation point to an
+    # unassigned slot; left in place they corrupt the word around them.
+    assert clean_extracted_text("de￾picted") == "depicted"
+
+
+def test_resolving_and_discarding_happen_together():
+    assert clean_extracted_text(f" {OLDSTYLE_2019}﻿") == "© 2019"
+
+
+def test_an_emoji_joiner_sequence_survives():
+    developer = "\U0001f469‍\U0001f4bb"
+    assert clean_extracted_text(developer) == developer
+
+
+def test_nothing_discardable_survives_a_clean():
+    messy = f"a­b￾c﷐d﻿{OLDSTYLE_2019}"
+
+    cleaned = clean_extracted_text(messy)
+
+    assert cleaned == "abcd2019"
+    assert not any(is_discardable_formatting(character) for character in cleaned)
+
+
+def test_empty_input_is_returned_unchanged():
+    assert clean_extracted_text("") == ""
+
+
+def test_a_line_final_soft_hyphen_becomes_a_hyphenation_point():
+    # Span text arrives as "hyphen<shy>\n".  Dropping the soft hyphen outright
+    # would leave a line ending in no hyphen at all, and marker would rejoin it
+    # as "hyphen ation"; a real hyphen is the signal the rest of marker reads.
+    assert clean_extracted_text("hyphen­\n") == "hyphen-\n"
+
+
+def test_a_line_final_noncharacter_becomes_a_hyphenation_point():
+    assert clean_extracted_text("de￾\n") == "de-\n"
+
+
+def test_a_mid_line_soft_hyphen_is_still_dropped():
+    assert clean_extracted_text("co­operate") == "cooperate"
+
+
+def test_a_hyphenation_point_is_not_doubled():
+    assert clean_extracted_text("hyphen-­\n") == "hyphen-\n"
+
+
+def test_a_trailing_soft_hyphen_with_no_line_break_is_dropped():
+    # Without a following break there is nothing to rejoin, so inventing a
+    # hyphen here would put one in the middle of a word.
+    assert clean_extracted_text("hyphen­") == "hyphen"

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,19 +1,46 @@
-from marker.providers.pdf import PdfProvider
 import tempfile
+from typing import Any, Dict, Optional
 
-import datasets
+import pytest
+
+from marker.providers.pdf import PdfProvider
+from tests.dataset import (
+    DEFAULT_DOCUMENT,
+    DocumentUnavailable,
+    load_document,
+    unavailable_reason,
+)
+
+
+def require_documents(*filenames: str) -> None:
+    """Skip the current test unless every named sample document can be loaded.
+
+    Call this before handing filenames to a worker process: a skip raised in a
+    worker would surface in the parent as a failure, not a skip.
+    """
+    for filename in filenames:
+        reason = unavailable_reason(filename)
+        if reason:
+            pytest.skip(reason)
 
 
 def setup_pdf_provider(
-    filename='adversarial.pdf',
-    config=None,
+    filename: str = DEFAULT_DOCUMENT,
+    config: Optional[Dict[str, Any]] = None,
 ) -> PdfProvider:
-    dataset = datasets.load_dataset("datalab-to/pdfs", split="train")
-    idx = dataset['filename'].index(filename)
+    """Build a PdfProvider over a sample document.
+
+    Raises :class:`DocumentUnavailable` when the document cannot be loaded;
+    callers running in-process should guard with :func:`require_documents` so
+    that turns into a skip.
+    """
+    content = load_document(filename)
 
     temp_pdf = tempfile.NamedTemporaryFile(suffix=".pdf")
-    temp_pdf.write(dataset['pdf'][idx])
+    temp_pdf.write(content)
     temp_pdf.flush()
 
-    provider = PdfProvider(temp_pdf.name, config)
-    return provider
+    return PdfProvider(temp_pdf.name, config)
+
+
+__all__ = ["DocumentUnavailable", "require_documents", "setup_pdf_provider"]


### PR DESCRIPTION
Five durability fixes for long batch runs, plus a change that lets the test suite run without access to the gated sample-document dataset. Each commit stands alone and can be dropped without affecting the others.

Based on `dev`. The six commits rebase onto it cleanly and are independent of the `master`-only history, so the diff is these changes and nothing else.

### Batch durability

- **Write outputs atomically** so `--skip_existing` can trust them. An interrupted run currently leaves a half-written file that a later run counts as finished and skips.
- **`--skip_existing` checks for output in the format being converted to.** Converting a folder to markdown, then rerunning with `--output_format json --skip_existing`, currently skips every file because a `.md` sits beside them.
- **Report which files a batch failed on.** A failed batch writes `conversion_failures.json` listing each file with its error, so a long run says what to retry rather than only how many failed.
- **Name a PDF that cannot be read** instead of failing somewhere inside PDFium.
- **Resolve font glyph variants** and drop layout-only characters from extracted text.

### Test suite without dataset access

`tests/conftest.py` loads `datalab-to/pdfs`, which is gated. CI has the `HF_TOKEN` secret so this is invisible there, but a contributor running the suite locally without access gets 70 errors out of fixture setup, plus one failure in `test_overriding_mp` (it calls `load_dataset` inside an `mp.Pool` worker, so it fails in-body rather than at setup).

Sample documents now resolve through `tests/dataset.py`: a local directory (`MARKER_TEST_PDF_DIR`, default `tests/data/pdfs/`) is consulted before the Hub, and if neither source has the document the test **skips with a reason** naming the file and both sources:

```
SKIPPED [1] tests/builders/test_document_builder.py:7: sample document
'thinkpython.pdf' is unavailable (local: no such file: tests/data/pdfs/thinkpython.pdf;
hub: DatasetNotFoundError: ...). Grant access with `huggingface-cli login` ..., or drop
the file into the local directory. See tests/README.md.
```

Behaviour with a token is unchanged — the Hub path is unchanged and covered by tests. A fully populated local directory runs the suite with no Hub access at all.

No sample documents are vendored. The tests assert on real content (the title of `adversarial.pdf`, its 12-page length), so a stand-in document loads fine and then fails those assertions — worse than skipping.

### Test plan

- [x] `uv run pytest -m "not integration"` — 65 passed, 73 skipped (skips are the corpus-backed tests, on a machine with no dataset access)
- [x] 43 new tests for the durability fixes (`test_output.py`, `test_preflight.py`, `test_text_cleanup.py`, `test_batch_outcomes.py`)
- [x] 14 new tests for document resolution, including the Hub path via a stub, so it stays covered without a token
- [x] `ruff check` and `black --check` clean on all changed files
- [ ] Full suite with dataset access — I can't run this (no access to the gated dataset)
- [ ] Integration/GPU tests — not run locally

Note that `ci.yml` and `scripts.yml` are both `on: [push]`, so neither runs on a fork PR — `CLAAssistant` is the only check that fires here. The two unchecked boxes above need a maintainer to run them, either after merge or by pushing the branch upstream.

### Note

This replaces #1094. I closed that one over the CLA; the lock-on-close workflow
then locked the thread, so it can't be commented on even after reopening. Same
branch, same commits, no changes to the diff. I'm signing the CLA here.


